### PR TITLE
Validate escrow monetary inputs

### DIFF
--- a/src/bounties/dto/create-bounty.dto.ts
+++ b/src/bounties/dto/create-bounty.dto.ts
@@ -1,12 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsEnum,
-  IsNumberString,
-  IsOptional,
-  IsUUID,
-  IsISO8601,
-} from 'class-validator';
+import { IsEnum, IsOptional, IsUUID, IsISO8601 } from 'class-validator';
 import { AssetType, BountyDifficulty } from '../../common/enums';
+import {
+  IsMoneyAmount,
+  IsSupportedEscrowAsset,
+} from '../../common/validators/money.validator';
 
 export class CreateBountyDto {
   @ApiProperty({
@@ -20,11 +18,11 @@ export class CreateBountyDto {
   sponsorId: string;
 
   @ApiProperty()
-  @IsNumberString()
+  @IsMoneyAmount()
   amount: string;
 
   @ApiProperty({ enum: AssetType, default: AssetType.USDC })
-  @IsEnum(AssetType)
+  @IsSupportedEscrowAsset()
   asset: AssetType;
 
   @ApiProperty({

--- a/src/common/validators/money.validator.ts
+++ b/src/common/validators/money.validator.ts
@@ -1,0 +1,76 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { AssetType } from '../enums';
+
+const STROOP_SCALE = 10_000_000n;
+const MAX_MAJOR_UNITS = 100_000_000n;
+
+export const MAX_MONETARY_AMOUNT = MAX_MAJOR_UNITS.toString();
+export const SUPPORTED_ESCROW_ASSETS = [AssetType.USDC, AssetType.XLM] as const;
+
+export function isValidMoneyAmount(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  if (!/^(0|[1-9]\d*)(\.\d{1,7})?$/.test(value)) return false;
+
+  const [whole, fraction = ''] = value.split('.');
+  const stroops =
+    BigInt(whole) * STROOP_SCALE + BigInt(fraction.padEnd(7, '0'));
+
+  return stroops > 0n && stroops <= MAX_MAJOR_UNITS * STROOP_SCALE;
+}
+
+export function amountToStroops(amount: string): bigint {
+  if (!isValidMoneyAmount(amount)) {
+    throw new Error(
+      `Amount must be a positive decimal string with at most 7 fractional digits and no more than ${MAX_MONETARY_AMOUNT}`,
+    );
+  }
+
+  const [whole, fraction = ''] = amount.split('.');
+  return BigInt(whole) * STROOP_SCALE + BigInt(fraction.padEnd(7, '0'));
+}
+
+export function isSupportedEscrowAsset(value: unknown): value is AssetType {
+  return SUPPORTED_ESCROW_ASSETS.includes(value as AssetType);
+}
+
+export function IsMoneyAmount(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isMoneyAmount',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          return isValidMoneyAmount(value);
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a positive decimal string with at most 7 fractional digits and no more than ${MAX_MONETARY_AMOUNT}`;
+        },
+      },
+    });
+  };
+}
+
+export function IsSupportedEscrowAsset(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isSupportedEscrowAsset',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          return isSupportedEscrowAsset(value);
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a supported escrow asset: ${SUPPORTED_ESCROW_ASSETS.join(', ')}`;
+        },
+      },
+    });
+  };
+}

--- a/src/escrow/dto/fund-escrow.dto.ts
+++ b/src/escrow/dto/fund-escrow.dto.ts
@@ -1,20 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsEnum,
-  IsNumberString,
-  IsOptional,
-  IsString,
-  IsUUID,
-} from 'class-validator';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { AssetType } from '../../common/enums';
+import {
+  IsMoneyAmount,
+  IsSupportedEscrowAsset,
+} from '../../common/validators/money.validator';
 
 export class FundEscrowDto {
   @ApiProperty({ description: 'Amount to lock in the escrow contract' })
-  @IsNumberString()
+  @IsMoneyAmount()
   amount: string;
 
   @ApiProperty({ enum: AssetType, default: AssetType.USDC })
-  @IsEnum(AssetType)
+  @IsSupportedEscrowAsset()
   asset: AssetType;
 
   @ApiProperty({ description: 'Stellar public key of the funding sponsor' })

--- a/src/escrow/escrow.service.spec.ts
+++ b/src/escrow/escrow.service.spec.ts
@@ -81,6 +81,45 @@ describe('EscrowService', () => {
         true,
       );
     });
+
+    it.each([
+      '0',
+      '-1',
+      '1e3',
+      '1,000',
+      'not-a-number',
+      '1.00000001',
+      '100000000.0000001',
+    ])(
+      'rejects malformed amount %s before escrow creation or chain calls',
+      async (amount) => {
+        await expect(
+          service.fund({
+            amount,
+            asset: AssetType.USDC,
+            funderAddress: 'G...FUNDER',
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(escrowRepo.create).not.toHaveBeenCalled();
+        expect(escrowRepo.save).not.toHaveBeenCalled();
+        expect(soroban.invoke).not.toHaveBeenCalled();
+      },
+    );
+
+    it('rejects unsupported assets before escrow creation or chain calls', async () => {
+      await expect(
+        service.fund({
+          amount: '10.0000000',
+          asset: 'BTC' as AssetType,
+          funderAddress: 'G...FUNDER',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(escrowRepo.create).not.toHaveBeenCalled();
+      expect(escrowRepo.save).not.toHaveBeenCalled();
+      expect(soroban.invoke).not.toHaveBeenCalled();
+    });
   });
 
   describe('release', () => {

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -8,6 +8,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Escrow, Payment } from '../common/entities';
 import { AssetType, EscrowStatus, PaymentStatus } from '../common/enums';
+import {
+  amountToStroops,
+  isSupportedEscrowAsset,
+  isValidMoneyAmount,
+} from '../common/validators/money.validator';
 import { SorobanClientService } from './soroban-client.service';
 
 export interface FundEscrowInput {
@@ -38,6 +43,8 @@ export class EscrowService {
 
   /** Locks funds for a bounty/milestone/pool by calling the escrow contract's `fund`. */
   async fund(input: FundEscrowInput): Promise<Escrow> {
+    this.assertValidFundInput(input);
+
     const escrow = this.escrowRepo.create({
       amount: input.amount,
       asset: input.asset,
@@ -58,7 +65,7 @@ export class EscrowService {
       const result = await this.soroban.invoke('fund', [
         input.funderAddress,
         referenceId,
-        BigInt(this.toStroops(input.amount)),
+        this.toStroops(input.amount),
       ]);
 
       escrow.status = EscrowStatus.LOCKED;
@@ -169,6 +176,7 @@ export class EscrowService {
   ): Promise<Payment> {
     const escrow = await this.getOrThrow(escrowId);
     this.assertLocked(escrow);
+    this.assertValidAmount(amount);
 
     const existingPayments = await this.paymentRepo.find({
       where: { escrowId: escrow.id },
@@ -187,7 +195,7 @@ export class EscrowService {
     const result = await this.soroban.invoke('release', [
       escrow.milestoneId ?? escrow.bountyId ?? escrow.id,
       recipientAddress,
-      BigInt(this.toStroops(amount)),
+      this.toStroops(amount),
     ]);
 
     const payment = await this.paymentRepo.save(
@@ -270,7 +278,24 @@ export class EscrowService {
     return Math.round(value * 1e7) / 1e7;
   }
 
-  private toStroops(amount: string): number {
-    return Math.round(Number(amount) * 1e7);
+  private assertValidFundInput(input: FundEscrowInput): void {
+    this.assertValidAmount(input.amount);
+    if (!isSupportedEscrowAsset(input.asset)) {
+      throw new BadRequestException(
+        `Unsupported escrow asset: ${String(input.asset)}`,
+      );
+    }
+  }
+
+  private assertValidAmount(amount: string): void {
+    if (!isValidMoneyAmount(amount)) {
+      throw new BadRequestException(
+        'Amount must be a positive decimal string with at most 7 fractional digits and no more than 100000000',
+      );
+    }
+  }
+
+  private toStroops(amount: string): bigint {
+    return amountToStroops(amount);
   }
 }

--- a/src/maintenance-pool/dto/create-pool.dto.ts
+++ b/src/maintenance-pool/dto/create-pool.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { AssetType } from '../../common/enums';
+import { IsSupportedEscrowAsset } from '../../common/validators/money.validator';
 
 export class CreatePoolDto {
   @ApiProperty()
@@ -18,6 +19,6 @@ export class CreatePoolDto {
   createdById?: string;
 
   @ApiProperty({ enum: AssetType, default: AssetType.USDC })
-  @IsEnum(AssetType)
+  @IsSupportedEscrowAsset()
   asset: AssetType;
 }

--- a/src/maintenance-pool/maintenance-pool.controller.ts
+++ b/src/maintenance-pool/maintenance-pool.controller.ts
@@ -1,11 +1,12 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { IsNumberString, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { MaintenancePoolService } from './maintenance-pool.service';
 import { CreatePoolDto } from './dto/create-pool.dto';
+import { IsMoneyAmount } from '../common/validators/money.validator';
 
 class DepositDto {
-  @IsNumberString()
+  @IsMoneyAmount()
   amount: string;
 
   @IsString()
@@ -13,7 +14,7 @@ class DepositDto {
 }
 
 class AssignRewardDto {
-  @IsNumberString()
+  @IsMoneyAmount()
   amount: string;
 
   @IsString()

--- a/src/milestones/dto/create-milestone.dto.ts
+++ b/src/milestones/dto/create-milestone.dto.ts
@@ -1,13 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsEnum,
-  IsISO8601,
-  IsNumberString,
-  IsOptional,
-  IsString,
-  IsUUID,
-} from 'class-validator';
+import { IsISO8601, IsOptional, IsString, IsUUID } from 'class-validator';
 import { AssetType } from '../../common/enums';
+import {
+  IsMoneyAmount,
+  IsSupportedEscrowAsset,
+} from '../../common/validators/money.validator';
 
 export class CreateMilestoneDto {
   @ApiProperty()
@@ -29,11 +26,11 @@ export class CreateMilestoneDto {
   description?: string;
 
   @ApiProperty()
-  @IsNumberString()
+  @IsMoneyAmount()
   budget: string;
 
   @ApiProperty({ enum: AssetType, default: AssetType.USDC })
-  @IsEnum(AssetType)
+  @IsSupportedEscrowAsset()
   asset: AssetType;
 
   @ApiProperty({ required: false })


### PR DESCRIPTION
## Summary
- add reusable money amount and escrow asset validators for DTO boundaries
- reject malformed, zero, over-precision, and oversized monetary strings before escrow persistence or Soroban calls
- convert decimal amounts to stroops with BigInt parsing instead of Number-based rounding
- add regression coverage for adversarial amount strings and unsupported assets

## Validation
- npm test -- escrow.service.spec.ts --runInBand
- npm test -- --runInBand
- npm run build
- npm run lint

Closes #29