### PR TITLE
fix: global exception filter to stop leaking internal error detail to clients

### DIFF
--- a/src/common/filters/global-exception.filter.integration.spec.ts
+++ b/src/common/filters/global-exception.filter.integration.spec.ts
@@ -1,0 +1,99 @@
+import {
+  Controller,
+  Get,
+  INestApplication,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { GlobalExceptionFilter } from './global-exception.filter';
+
+/**
+ * Minimal throwaway controller exercising the same shapes described in #19:
+ * a raw (non-HttpException) error simulating a Soroban/TypeORM failure, and
+ * a legitimate validation-style HttpException. Deliberately doesn't import
+ * AppModule (which needs a live Postgres connection) — this only needs the
+ * filter wired up exactly as main.ts wires it.
+ */
+@Controller('test')
+class ThrowingController {
+  @Get('soroban-failure')
+  sorobanFailure(): never {
+    throw new Error(
+      'Soroban simulation failed: HostError: Error(Contract, #1), account GABC...SECRET123 keypair mismatch',
+    );
+  }
+
+  @Get('db-failure')
+  dbFailure(): never {
+    throw new Error(
+      'insert or update on table "escrows" violates foreign key constraint "FK_escrows_bountyId"',
+    );
+  }
+
+  @Get('not-found')
+  notFound(): never {
+    throw new NotFoundException('Escrow esc_1 not found');
+  }
+}
+
+describe('GlobalExceptionFilter (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [ThrowingController],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    // Silence Nest's console logging for this test — we assert on the
+    // response body, and separately unit-test that the filter's Logger
+    // calls happen (global-exception.filter.spec.ts); no need for either
+    // to spam real console output here.
+    app.useLogger(false);
+    app.useGlobalFilters(new GlobalExceptionFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('sanitizes a raw Soroban error and never includes its content in the response', async () => {
+    const res = await request(app.getHttpServer()).get('/test/soroban-failure');
+
+    expect(res.status).toBe(500);
+    const raw = JSON.stringify(res.body);
+    expect(raw).not.toContain('SECRET123');
+    expect(raw).not.toContain('HostError');
+    expect(raw).not.toContain('Contract, #1');
+    expect(res.body).toEqual({
+      statusCode: 500,
+      message: expect.stringContaining('reference ID') as string,
+      errorId: expect.any(String) as string,
+    });
+  });
+
+  it('sanitizes a raw DB error and never includes schema/table detail', async () => {
+    const res = await request(app.getHttpServer()).get('/test/db-failure');
+
+    expect(res.status).toBe(500);
+    const raw = JSON.stringify(res.body);
+    expect(raw).not.toContain('FK_escrows_bountyId');
+    expect(raw).not.toContain('violates foreign key');
+  });
+
+  it('leaves a legitimate NotFoundException response untouched', async () => {
+    const res = await request(app.getHttpServer()).get('/test/not-found');
+    const body = res.body as { errorId?: string };
+
+    expect(res.status).toBe(404);
+    expect(body).toEqual({
+      statusCode: 404,
+      message: 'Escrow esc_1 not found',
+      error: 'Not Found',
+    });
+    expect(body.errorId).toBeUndefined();
+  });
+});

--- a/src/common/filters/global-exception.filter.spec.ts
+++ b/src/common/filters/global-exception.filter.spec.ts
@@ -1,0 +1,168 @@
+import {
+  ArgumentsHost,
+  BadRequestException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { GlobalExceptionFilter } from './global-exception.filter';
+
+interface SanitizedBody {
+  statusCode: number;
+  message: string;
+  errorId: string;
+}
+
+function createMockHost(overrides: { method?: string; url?: string } = {}) {
+  const json = jest.fn<void, [unknown]>();
+  const status = jest.fn(() => ({ json }));
+  const response = { status };
+  const request = {
+    method: overrides.method ?? 'GET',
+    url: overrides.url ?? '/api/escrow/esc_1',
+    originalUrl: overrides.url ?? '/api/escrow/esc_1',
+  };
+
+  const host = {
+    switchToHttp: () => ({
+      getResponse: () => response,
+      getRequest: () => request,
+    }),
+  } as unknown as ArgumentsHost;
+
+  return { host, status, json };
+}
+
+function sanitizedBodyOf(json: jest.Mock<void, [unknown]>): SanitizedBody {
+  return json.mock.calls[0][0] as SanitizedBody;
+}
+
+describe('GlobalExceptionFilter', () => {
+  let filter: GlobalExceptionFilter;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance<void, [string, string?]>;
+
+  beforeEach(() => {
+    filter = new GlobalExceptionFilter();
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    errorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation() as jest.SpyInstance<void, [string, string?]>;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('safe client errors (HttpException, status < 500)', () => {
+    it('passes a BadRequestException response through unmodified', () => {
+      const { host, status, json } = createMockHost();
+      const exception = new BadRequestException('Amount must be positive');
+
+      filter.catch(exception, host);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith(exception.getResponse());
+      // Unaffected: no errorId injected, no message rewritten.
+      expect(json.mock.calls[0][0]).toEqual({
+        statusCode: 400,
+        message: 'Amount must be positive',
+        error: 'Bad Request',
+      });
+    });
+
+    it('passes a NotFoundException response through unmodified', () => {
+      const { host, status, json } = createMockHost();
+      const exception = new NotFoundException('Escrow esc_1 not found');
+
+      filter.catch(exception, host);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith(exception.getResponse());
+    });
+
+    it('logs safe client errors at warn level, not error', () => {
+      const { host } = createMockHost();
+      filter.catch(new BadRequestException('bad input'), host);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sanitized errors (raw Error, or HttpException status >= 500)', () => {
+    it('does not leak a raw Soroban simulation error message into the response', () => {
+      const { host, status, json } = createMockHost();
+      const rawError = new Error(
+        'Soroban simulation failed: contract trap: HostError: Error(Contract, #1) at soroban-rpc.internal:8000',
+      );
+
+      filter.catch(rawError, host);
+
+      expect(status).toHaveBeenCalledWith(500);
+      const body = sanitizedBodyOf(json);
+      expect(JSON.stringify(body)).not.toContain('soroban-rpc.internal');
+      expect(JSON.stringify(body)).not.toContain('HostError');
+      expect(body).toMatchObject({
+        statusCode: 500,
+        message: expect.stringContaining('reference ID') as string,
+      });
+      expect(typeof body.errorId).toBe('string');
+    });
+
+    it('does not leak a raw TypeORM/Postgres error message into the response', () => {
+      const { host, json } = createMockHost();
+      const dbError = new Error(
+        'duplicate key value violates unique constraint "UQ_bounties_issueId" on table "bounties"',
+      );
+
+      filter.catch(dbError, host);
+
+      const body = sanitizedBodyOf(json);
+      expect(JSON.stringify(body)).not.toContain('UQ_bounties_issueId');
+      expect(JSON.stringify(body)).not.toContain('bounties');
+    });
+
+    it('logs the full raw error message and stack server-side', () => {
+      const { host } = createMockHost();
+      const rawError = new Error('Soroban simulation failed: sensitive detail');
+
+      filter.catch(rawError, host);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const [logMessage, logStack] = errorSpy.mock.calls[0];
+      expect(logMessage).toContain('sensitive detail');
+      expect(logStack).toBe(rawError.stack);
+    });
+
+    it('includes the same errorId in both the response and the log line', () => {
+      const { host, json } = createMockHost();
+      filter.catch(new Error('boom'), host);
+
+      const body = sanitizedBodyOf(json);
+      const [logMessage] = errorSpy.mock.calls[0];
+      expect(logMessage).toContain(body.errorId);
+    });
+
+    it('generates a distinct errorId per exception', () => {
+      const first = createMockHost();
+      const second = createMockHost();
+
+      filter.catch(new Error('first'), first.host);
+      filter.catch(new Error('second'), second.host);
+
+      const firstId = sanitizedBodyOf(first.json).errorId;
+      const secondId = sanitizedBodyOf(second.json).errorId;
+      expect(firstId).not.toBe(secondId);
+    });
+
+    it('sanitizes a non-Error thrown value (e.g. a thrown string)', () => {
+      const { host, status, json } = createMockHost();
+
+      filter.catch('a raw thrown string with internal detail', host);
+
+      expect(status).toHaveBeenCalledWith(500);
+      const body = sanitizedBodyOf(json);
+      expect(JSON.stringify(body)).not.toContain('internal detail');
+    });
+  });
+});

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -1,0 +1,78 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+
+/**
+ * Catches every unhandled exception reaching the HTTP layer and draws a
+ * single, principled line between what's safe to show a client and what
+ * isn't: the HTTP status code.
+ *
+ *  - HttpExceptions with a status below 500 (BadRequestException,
+ *    NotFoundException, UnauthorizedException, ConflictException, etc.)
+ *    are *intentional, validated, client-facing* messages — authored by
+ *    application code specifically to be read by whoever's calling the
+ *    API. These pass through completely unmodified, response body and
+ *    all, so nothing about existing validation-error behavior changes.
+ *  - Everything else — a raw `Error` (e.g. a Soroban simulation failure
+ *    or a TypeORM/Postgres error, neither of which are HttpExceptions),
+ *    or any HttpException whose status is 500+ — is internal-only detail
+ *    that must never reach a client. These get a generic message and a
+ *    correlation `errorId` the caller can quote when reporting the issue,
+ *    while the full original error (message + stack) is always logged
+ *    server-side at `error` level.
+ *
+ * Registered globally in main.ts via `app.useGlobalFilters(...)` (#19).
+ */
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const internalServerErrorStatus: number = HttpStatus.INTERNAL_SERVER_ERROR;
+    const isHttpException = exception instanceof HttpException;
+    const status: number = isHttpException
+      ? exception.getStatus()
+      : internalServerErrorStatus;
+    const isSafeClientError =
+      isHttpException && status < internalServerErrorStatus;
+
+    const error =
+      exception instanceof Error ? exception : new Error(String(exception));
+    const errorId = randomUUID();
+    const context = `${request.method} ${request.originalUrl ?? request.url}`;
+
+    if (isSafeClientError) {
+      // Still worth a log line (helps correlate client-reported issues to
+      // requests), but at warn — this is expected application behavior,
+      // not a bug — and the response body is untouched.
+      this.logger.warn(
+        `[${errorId}] ${context} -> ${status}: ${error.message}`,
+      );
+      response.status(status).json(exception.getResponse());
+      return;
+    }
+
+    this.logger.error(
+      `[${errorId}] ${context} -> ${status}: ${error.message}`,
+      error.stack,
+    );
+
+    response.status(status).json({
+      statusCode: status,
+      message:
+        'An unexpected error occurred. Please contact support with this reference ID.',
+      errorId,
+    });
+  }
+}

--- a/src/escrow/escrow-response.mapper.spec.ts
+++ b/src/escrow/escrow-response.mapper.spec.ts
@@ -1,0 +1,80 @@
+import { Escrow } from '../common/entities';
+import { AssetType, EscrowStatus } from '../common/enums';
+import { toPublicEscrow } from './escrow-response.mapper';
+
+function makeEscrow(overrides: Partial<Escrow> = {}): Escrow {
+  return {
+    id: 'esc_1',
+    bounty: null,
+    bountyId: 'bounty_1',
+    milestone: null,
+    milestoneId: null,
+    maintenancePool: null,
+    maintenancePoolId: null,
+    sponsorId: 'sponsor_1',
+    contractId: null,
+    amount: '100.0000000',
+    asset: AssetType.USDC,
+    status: EscrowStatus.FAILED,
+    fundedByAddress: 'GFUNDER',
+    fundTxHash: null,
+    releaseTxHash: null,
+    refundTxHash: null,
+    metadata: {
+      error:
+        'Soroban simulation failed: HostError: Error(Contract, #1), account GABC...SECRET keypair mismatch',
+    },
+    payments: [],
+    lockedAt: null,
+    releasedAt: null,
+    refundedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('toPublicEscrow', () => {
+  it('strips metadata from the returned object', () => {
+    const escrow = makeEscrow();
+
+    const publicEscrow = toPublicEscrow(escrow);
+
+    expect(publicEscrow).not.toHaveProperty('metadata');
+    expect(JSON.stringify(publicEscrow)).not.toContain('SECRET');
+    expect(JSON.stringify(publicEscrow)).not.toContain('HostError');
+  });
+
+  it('preserves every other field unchanged', () => {
+    const escrow = makeEscrow();
+
+    const publicEscrow = toPublicEscrow(escrow);
+
+    expect(publicEscrow).toMatchObject({
+      id: 'esc_1',
+      bountyId: 'bounty_1',
+      sponsorId: 'sponsor_1',
+      amount: '100.0000000',
+      status: EscrowStatus.FAILED,
+      fundedByAddress: 'GFUNDER',
+    });
+  });
+
+  it('strips metadata even when it contains successful Soroban result data', () => {
+    const escrow = makeEscrow({
+      status: EscrowStatus.LOCKED,
+      metadata: {
+        fund: {
+          txHash: 'abc',
+          ledger: 42,
+          returnValue: null,
+          status: 'SUCCESS',
+        },
+      },
+    });
+
+    const publicEscrow = toPublicEscrow(escrow);
+
+    expect(publicEscrow).not.toHaveProperty('metadata');
+  });
+});

--- a/src/escrow/escrow-response.mapper.ts
+++ b/src/escrow/escrow-response.mapper.ts
@@ -1,0 +1,22 @@
+import { Escrow } from '../common/entities';
+
+export type PublicEscrow = Omit<Escrow, 'metadata'>;
+
+/**
+ * Strips `metadata` before an Escrow reaches an HTTP client. `metadata`
+ * intentionally stores raw diagnostic detail from Soroban RPC calls —
+ * including, on a failed `fund`, the raw error message
+ * (`EscrowService.fund`'s catch block) — which is exactly the class of
+ * internal detail #19 is about keeping server-side only (useful here for
+ * debugging via direct DB access, never via the API response).
+ *
+ * Deliberately applied at the controller boundary, not inside
+ * `EscrowService`: other services (`BountiesService`, `MilestonesService`)
+ * consume the full `Escrow` entity returned by `EscrowService.fund`
+ * internally and shouldn't have to work around a narrowed return type.
+ */
+export function toPublicEscrow(escrow: Escrow): PublicEscrow {
+  const publicEscrow: Partial<Escrow> = { ...escrow };
+  delete publicEscrow.metadata;
+  return publicEscrow as PublicEscrow;
+}

--- a/src/escrow/escrow.controller.spec.ts
+++ b/src/escrow/escrow.controller.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EscrowController } from './escrow.controller';
+import { EscrowService } from './escrow.service';
+import { AssetType, EscrowStatus } from '../common/enums';
+import { Escrow } from '../common/entities';
+
+function makeEscrowWithLeakyMetadata(): Escrow {
+  return {
+    id: 'esc_1',
+    bounty: null,
+    bountyId: 'bounty_1',
+    milestone: null,
+    milestoneId: null,
+    maintenancePool: null,
+    maintenancePoolId: null,
+    sponsorId: 'sponsor_1',
+    contractId: null,
+    amount: '100.0000000',
+    asset: AssetType.USDC,
+    status: EscrowStatus.FAILED,
+    fundedByAddress: 'GFUNDER',
+    fundTxHash: null,
+    releaseTxHash: null,
+    refundTxHash: null,
+    metadata: {
+      error:
+        'Soroban simulation failed: internal RPC detail that must never reach a client',
+    },
+    payments: [],
+    lockedAt: null,
+    releasedAt: null,
+    refundedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe('EscrowController (#19 metadata leak)', () => {
+  let controller: EscrowController;
+  let escrowService: {
+    fund: jest.Mock;
+    findOne: jest.Mock;
+    release: jest.Mock;
+    refund: jest.Mock;
+    splitRelease: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    escrowService = {
+      fund: jest.fn().mockResolvedValue(makeEscrowWithLeakyMetadata()),
+      findOne: jest.fn().mockResolvedValue(makeEscrowWithLeakyMetadata()),
+      release: jest.fn().mockResolvedValue(makeEscrowWithLeakyMetadata()),
+      refund: jest.fn().mockResolvedValue(makeEscrowWithLeakyMetadata()),
+      splitRelease: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EscrowController],
+      providers: [{ provide: EscrowService, useValue: escrowService }],
+    }).compile();
+
+    controller = module.get(EscrowController);
+  });
+
+  it('fund() never returns metadata to the client', async () => {
+    const result = await controller.fund({
+      amount: '100',
+      asset: AssetType.USDC,
+      funderAddress: 'GFUNDER',
+      bountyId: 'bounty_1',
+    });
+
+    expect(result).not.toHaveProperty('metadata');
+    expect(JSON.stringify(result)).not.toContain('internal RPC detail');
+  });
+
+  it('findOne() (GET /escrow/:id) never returns metadata to the client', async () => {
+    const result = await controller.findOne('esc_1');
+
+    expect(result).not.toHaveProperty('metadata');
+    expect(JSON.stringify(result)).not.toContain('internal RPC detail');
+  });
+
+  it('release() never returns metadata to the client', async () => {
+    const result = await controller.release('esc_1', {
+      recipientAddress: 'GRECIPIENT',
+    });
+
+    expect(result).not.toHaveProperty('metadata');
+  });
+
+  it('refund() never returns metadata to the client', async () => {
+    const result = await controller.refund('esc_1');
+
+    expect(result).not.toHaveProperty('metadata');
+  });
+});

--- a/src/escrow/escrow.controller.ts
+++ b/src/escrow/escrow.controller.ts
@@ -4,6 +4,7 @@ import { EscrowService } from './escrow.service';
 import { FundEscrowDto } from './dto/fund-escrow.dto';
 import { ReleaseEscrowDto } from './dto/release-escrow.dto';
 import { SplitReleaseDto } from './dto/split-release.dto';
+import { toPublicEscrow } from './escrow-response.mapper';
 
 @ApiTags('escrow')
 @Controller('escrow')
@@ -11,21 +12,23 @@ export class EscrowController {
   constructor(private readonly escrowService: EscrowService) {}
 
   @Post('fund')
-  fund(@Body() dto: FundEscrowDto) {
-    return this.escrowService.fund(dto);
+  async fund(@Body() dto: FundEscrowDto) {
+    return toPublicEscrow(await this.escrowService.fund(dto));
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.escrowService.findOne(id);
+  async findOne(@Param('id') id: string) {
+    return toPublicEscrow(await this.escrowService.findOne(id));
   }
 
   @Post(':id/release')
-  release(@Param('id') id: string, @Body() dto: ReleaseEscrowDto) {
-    return this.escrowService.release(
-      id,
-      dto.recipientAddress,
-      dto.recipientId,
+  async release(@Param('id') id: string, @Body() dto: ReleaseEscrowDto) {
+    return toPublicEscrow(
+      await this.escrowService.release(
+        id,
+        dto.recipientAddress,
+        dto.recipientId,
+      ),
     );
   }
 
@@ -35,7 +38,7 @@ export class EscrowController {
   }
 
   @Post(':id/refund')
-  refund(@Param('id') id: string) {
-    return this.escrowService.refund(id);
+  async refund(@Param('id') id: string) {
+    return toPublicEscrow(await this.escrowService.refund(id));
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { AppConfig } from './config/configuration';
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 
 const INSECURE_DEFAULT_JWT_SECRET = 'insecure-dev-secret';
 
@@ -36,6 +37,7 @@ async function bootstrap() {
       forbidNonWhitelisted: false,
     }),
   );
+  app.useGlobalFilters(new GlobalExceptionFilter());
 
   const swaggerConfig = new DocumentBuilder()
     .setTitle('MergeFi API')


### PR DESCRIPTION
## Summary

Fixes #19.

No global `ExceptionFilter` was registered anywhere in the app, and several service-layer methods (`SorobanClientService.invoke`, most notably) throw raw `Error` objects with interpolated internal detail — a Soroban simulation-error string (potentially including contract execution traces or RPC endpoint detail) and a JSON-stringified transaction error-result object. Nothing caught and sanitized these before they could reach an HTTP response.

### 1. `GlobalExceptionFilter` (`src/common/filters/global-exception.filter.ts`)

Registered via `app.useGlobalFilters(...)` in `main.ts`, as the requirements specify. Draws one principled boundary — **HTTP status code**, not exception class:

- `HttpException`s with status `< 500` (`BadRequestException`, `NotFoundException`, `UnauthorizedException`, `ValidationPipe` failures, etc.) are intentional, validated, client-facing messages — pass through **completely unmodified**, response body and all.
- Everything else — any raw `Error` (Soroban/TypeORM/anything not an `HttpException`), or an `HttpException` at 500+ — is sanitized: the client gets a generic message plus a correlation `errorId` to quote when reporting the issue, while the full error (message + stack) is always logged server-side at `error` level.

This status-based rule covers any current or future `HttpException` by actual severity rather than an enumerated "trusted" class list, and categorically strips detail from raw Errors regardless of where in the call stack they originate — satisfying the requirements' explicit "OR ensure the global filter categorically strips detail from any non-HttpException error" clause without needing to touch every raw-`Error` throw site individually.

### 2. A second leak the filter alone doesn't cover

Investigating "does the raw simulation error detail reach the HTTP response body" for `EscrowService.fund` turned up something not exception-shaped at all: `fund`'s catch block persists the raw Soroban error message into `escrow.metadata.error` on failure, and `EscrowController`'s endpoints return the raw `Escrow` entity — `metadata` included — directly as the HTTP response body. A failed `fund()` call itself throws (now sanitized by the filter), but a **subsequent** `GET /escrow/:id` for that same escrow returns the persisted entity as an ordinary 200 response, with the raw internal error message sitting in the JSON body — no exception involved, so the filter never sees it.

Fixed with `toPublicEscrow` (`src/escrow/escrow-response.mapper.ts`), applied at the controller boundary across `fund`/`findOne`/`release`/`refund` (`splitRelease` returns `Payment[]`, unaffected — no `metadata` field there). Deliberately not applied inside `EscrowService` itself: `BountiesService`/`MilestonesService` consume the full `Escrow` entity returned by `EscrowService.fund` internally, so narrowing the service's own return type would break those callers for no benefit.

## Test plan
- [x] `npx jest` — 81/81 passing (the one pre-existing DB-integration spec from an earlier PR fails locally as expected — no live Postgres in this environment; it runs against CI's real Postgres service)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `global-exception.filter.spec.ts` (unit) — raw Soroban-style and raw TypeORM-style errors both sanitized with zero trace of the original message in the response while fully logged server-side; `BadRequestException`/`NotFoundException` pass through byte-for-byte; safe errors log at `warn`, sanitized at `error`; same `errorId` in response and log line; distinct `errorId` per exception; non-`Error` thrown values also sanitized
- [x] `global-exception.filter.integration.spec.ts` — real Nest app + supertest, asserting actual HTTP response bodies (no `AppModule`/DB dependency)
- [x] `escrow-response.mapper.spec.ts` + `escrow.controller.spec.ts` — confirm `metadata` is stripped (both the failure and success shapes) and never reaches the client across every `Escrow`-returning endpoint