### PR TITLE
feat: end-to-end Idempotency-Key support for fund/claim/release/refund endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,31 @@ Route groups: `/api/auth`, `/api/users`, `/api/github`,
 `/api/escrow`, `/api/teams`, `/api/milestones`, `/api/maintenance-pools`,
 `/api/sponsors`, `/api/reputation`, `/api/analytics`.
 
+### Idempotency
+
+Every fund/claim/release/refund mutation — `POST /bounties/:id/fund`,
+`/claim`, `/refund`; `/escrow/fund`, `/escrow/:id/release`,
+`/escrow/:id/split-release`, `/escrow/:id/refund`; `/milestones/:id/fund`,
+`/milestones/:id/issues/:issueId/resolve`; `/maintenance-pools/:id/deposit`,
+`/maintenance-pools/:id/assign-reward` — requires a client-supplied
+`Idempotency-Key` header (a UUID) so a retried request after a dropped
+connection can't double-execute:
+
+- A repeated request with the same key (scoped per endpoint and, once a
+  route requires auth, per caller) returns the original response without
+  re-running the mutation. 2xx and 4xx outcomes are cached and replayed
+  verbatim; a 5xx is not cached, so a retry after a genuine server error
+  runs cleanly rather than replaying the failure forever.
+- A second request reusing a key that's still mid-flight gets `409
+  Conflict` instead of racing into a duplicate execution. If the original
+  request crashed before completing, the key is reclaimed after 30s so it
+  doesn't 409 forever.
+- Cached keys are retained for 24h (`IDEMPOTENCY_KEY_TTL_MS` in
+  `IdempotencyInterceptor`) and swept hourly by `IdempotencyCleanupService`.
+
+See `src/common/idempotency/` for the interceptor, decorator, and cleanup
+job.
+
 ## Setup, run, test
 
 You can run this project either natively on your host machine or completely containerized using Docker.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.5",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.3",
@@ -2458,6 +2459,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.1.0.tgz",
@@ -3252,6 +3266,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5359,6 +5379,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8187,6 +8224,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.5",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import configuration, { AppConfig } from './config/configuration';
@@ -18,11 +19,13 @@ import { SponsorsModule } from './sponsors/sponsors.module';
 import { MaintenancePoolModule } from './maintenance-pool/maintenance-pool.module';
 import { ReputationModule } from './reputation/reputation.module';
 import { AnalyticsModule } from './analytics/analytics.module';
+import { IdempotencyModule } from './common/idempotency/idempotency.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true, load: [configuration] }),
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 120 }]),
+    ScheduleModule.forRoot(),
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService<AppConfig, true>) => {
@@ -47,6 +50,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
     MaintenancePoolModule,
     ReputationModule,
     AnalyticsModule,
+    IdempotencyModule,
   ],
   controllers: [AppController],
   providers: [AppService, { provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/src/bounties/bounties.controller.ts
+++ b/src/bounties/bounties.controller.ts
@@ -5,6 +5,7 @@ import { BountiesService } from './bounties.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
 import { ClaimBountyDto } from './dto/claim-bounty.dto';
 import { BountyStatus } from '../common/enums';
+import { Idempotent } from '../common/idempotency/idempotent.decorator';
 
 class FundBountyDto {
   @IsString()
@@ -31,16 +32,19 @@ export class BountiesController {
     return this.bountiesService.findOne(id);
   }
 
+  @Idempotent('bounty.fund')
   @Post(':id/fund')
   fund(@Param('id') id: string, @Body() dto: FundBountyDto) {
     return this.bountiesService.fund(id, dto.funderAddress);
   }
 
+  @Idempotent('bounty.claim')
   @Post(':id/claim')
   claim(@Param('id') id: string, @Body() dto: ClaimBountyDto) {
     return this.bountiesService.claim(id, dto.contributorId);
   }
 
+  @Idempotent('bounty.refund')
   @Post(':id/refund')
   refund(@Param('id') id: string) {
     return this.bountiesService.refund(id);

--- a/src/common/entities/idempotency-key.entity.ts
+++ b/src/common/entities/idempotency-key.entity.ts
@@ -1,0 +1,75 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { IdempotencyKeyStatus } from '../enums';
+
+/**
+ * One row per (Idempotency-Key header value, endpoint scope, caller) tuple
+ * seen on an idempotency-guarded mutation endpoint (#16).
+ *
+ * The unique index below is the actual concurrency-safety mechanism: two
+ * simultaneous requests carrying the same key/scope/caller both attempt an
+ * INSERT, the database allows exactly one to succeed, and the loser reads
+ * back the winner's row instead of racing into a second execution of the
+ * underlying mutation. This is why `IdempotencyInterceptor` uses a plain
+ * `repo.insert(...)` wrapped in a try/catch for the unique-violation error,
+ * rather than a "check then insert" — the DB constraint is what actually
+ * closes the TOCTOU gap; a JS-level check-then-act would just relocate it.
+ */
+@Entity('idempotency_keys')
+@Index(['key', 'scope', 'callerId'], { unique: true })
+export class IdempotencyKey {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The raw Idempotency-Key header value the client supplied. */
+  @Column()
+  key: string;
+
+  /** Which endpoint this key applies to, e.g. 'bounty.fund' — keys are only unique per scope, not globally. */
+  @Column()
+  scope: string;
+
+  /**
+   * The caller this key belongs to — `req.user.userId` when the route is
+   * authenticated, or a documented fallback when it isn't (none of the
+   * mutation endpoints this guards currently require auth; see the
+   * interceptor for the exact fallback and its tracked limitation).
+   */
+  @Column()
+  callerId: string;
+
+  @Column({
+    type: 'enum',
+    enum: IdempotencyKeyStatus,
+    default: IdempotencyKeyStatus.PROCESSING,
+  })
+  status: IdempotencyKeyStatus;
+
+  /** HTTP status of the cached outcome, set once status moves to COMPLETED. */
+  @Column({ type: 'int', nullable: true })
+  responseStatus: number | null;
+
+  /** Response body of the cached outcome, set once status moves to COMPLETED. */
+  @Column({ type: 'jsonb', nullable: true })
+  responseBody: unknown;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  /**
+   * Retention TTL (see IdempotencyCleanupService) — completed keys older
+   * than this are safe to garbage-collect since no legitimate client retry
+   * would plausibly arrive this late.
+   */
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+}

--- a/src/common/entities/idempotency-key.entity.ts
+++ b/src/common/entities/idempotency-key.entity.ts
@@ -9,6 +9,17 @@ import {
 import { IdempotencyKeyStatus } from '../enums';
 
 /**
+ * Shape jsonb can actually hold — narrower than `unknown` so TypeORM's
+ * update()/insert() typings resolve cleanly. Deliberately not a fully
+ * recursive JSON type (nested values are `unknown`, not `JsonValue`) —
+ * combining self-referential types with TypeORM's own recursive
+ * QueryDeepPartialEntity<T> mapped type blows past TS's instantiation
+ * depth limit ("Type instantiation is excessively deep").
+ */
+export type JsonValue =
+  Record<string, unknown> | unknown[] | string | number | boolean | null;
+
+/**
  * One row per (Idempotency-Key header value, endpoint scope, caller) tuple
  * seen on an idempotency-guarded mutation endpoint (#16).
  *
@@ -57,7 +68,7 @@ export class IdempotencyKey {
 
   /** Response body of the cached outcome, set once status moves to COMPLETED. */
   @Column({ type: 'jsonb', nullable: true })
-  responseBody: unknown;
+  responseBody: JsonValue;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/common/entities/index.ts
+++ b/src/common/entities/index.ts
@@ -11,3 +11,4 @@ export * from './milestone.entity';
 export * from './maintenance-pool.entity';
 export * from './reputation-snapshot.entity';
 export * from './webhook-event.entity';
+export * from './idempotency-key.entity';

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -81,3 +81,18 @@ export enum WebhookEventStatus {
   IGNORED = 'ignored',
   FAILED = 'failed',
 }
+
+/**
+ * processing -> a request with this key is currently executing; a second
+ *               request with the same key while still processing is
+ *               rejected (409) rather than racing into a duplicate
+ *               execution.
+ * completed  -> the underlying mutation ran to completion (success or a
+ *               deterministic 4xx client error) and its outcome is cached;
+ *               a repeat request with the same key replays it verbatim
+ *               instead of re-executing.
+ */
+export enum IdempotencyKeyStatus {
+  PROCESSING = 'processing',
+  COMPLETED = 'completed',
+}

--- a/src/common/idempotency/idempotency-cleanup.service.spec.ts
+++ b/src/common/idempotency/idempotency-cleanup.service.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { LessThan } from 'typeorm';
+import { IdempotencyKey } from '../entities/idempotency-key.entity';
+import { IdempotencyCleanupService } from './idempotency-cleanup.service';
+
+interface DeleteCriteria {
+  expiresAt: ReturnType<typeof LessThan>;
+}
+
+describe('IdempotencyCleanupService', () => {
+  let service: IdempotencyCleanupService;
+  let repo: {
+    delete: jest.Mock<Promise<{ affected: number }>, [DeleteCriteria]>;
+  };
+
+  beforeEach(async () => {
+    repo = {
+      delete: jest
+        .fn<Promise<{ affected: number }>, [DeleteCriteria]>()
+        .mockResolvedValue({ affected: 0 }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IdempotencyCleanupService,
+        { provide: getRepositoryToken(IdempotencyKey), useValue: repo },
+      ],
+    }).compile();
+
+    service = module.get(IdempotencyCleanupService);
+  });
+
+  it('deletes rows whose expiresAt has already passed', async () => {
+    repo.delete.mockResolvedValue({ affected: 3 });
+
+    await service.removeExpired();
+
+    expect(repo.delete).toHaveBeenCalledTimes(1);
+    const criteria = repo.delete.mock.calls[0][0];
+    expect(criteria.expiresAt).toEqual(LessThan(expect.any(Date) as Date));
+  });
+
+  it('does not throw when nothing is expired', async () => {
+    repo.delete.mockResolvedValue({ affected: 0 });
+
+    await expect(service.removeExpired()).resolves.toBeUndefined();
+  });
+});

--- a/src/common/idempotency/idempotency-cleanup.service.ts
+++ b/src/common/idempotency/idempotency-cleanup.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import { IdempotencyKey } from '../entities/idempotency-key.entity';
+
+/**
+ * Sweeps expired idempotency_keys rows (#16). Retention itself is set per
+ * row at insert time via IDEMPOTENCY_KEY_TTL_MS
+ * (IdempotencyInterceptor.claim) — this just reclaims storage for rows
+ * whose `expiresAt` has already passed; it plays no part in correctness
+ * (a request replaying an already-deleted key simply executes as new).
+ */
+@Injectable()
+export class IdempotencyCleanupService {
+  private readonly logger = new Logger(IdempotencyCleanupService.name);
+
+  constructor(
+    @InjectRepository(IdempotencyKey)
+    private readonly repo: Repository<IdempotencyKey>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async removeExpired(): Promise<void> {
+    const result = await this.repo.delete({
+      expiresAt: LessThan(new Date()),
+    });
+    if (result.affected) {
+      this.logger.log(`Removed ${result.affected} expired idempotency key(s)`);
+    }
+  }
+}

--- a/src/common/idempotency/idempotency.interceptor.spec.ts
+++ b/src/common/idempotency/idempotency.interceptor.spec.ts
@@ -1,0 +1,359 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { firstValueFrom, lastValueFrom, of, throwError } from 'rxjs';
+import { IdempotencyKey } from '../entities/idempotency-key.entity';
+import { IdempotencyKeyStatus } from '../enums';
+import { IDEMPOTENCY_SCOPE_KEY } from './idempotent.decorator';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+const PG_UNIQUE_VIOLATION = '23505';
+const STALE_PROCESSING_MS = 30 * 1000;
+
+function uniqueViolationError(): Error & { driverError: { code: string } } {
+  return Object.assign(
+    new Error('duplicate key value violates unique constraint'),
+    { driverError: { code: PG_UNIQUE_VIOLATION } },
+  );
+}
+
+function matches(
+  row: IdempotencyKey,
+  criteria: Partial<IdempotencyKey>,
+): boolean {
+  return (Object.keys(criteria) as (keyof IdempotencyKey)[]).every((k) => {
+    const expected = criteria[k];
+    const actual = row[k];
+    if (expected instanceof Date) {
+      return actual instanceof Date && actual.getTime() === expected.getTime();
+    }
+    return actual === expected;
+  });
+}
+
+/**
+ * In-memory stand-in for Repository<IdempotencyKey> covering only the
+ * methods IdempotencyInterceptor calls. `insert` mimics the DB unique
+ * index on (key, scope, callerId) — the actual concurrency-safety
+ * primitive under test — with a synchronous check-and-push, which is
+ * enough to reproduce a real race: JS never preempts mid-microtask, so
+ * two `intercept()` calls racing to insert the same key interleave at
+ * `await` boundaries exactly like two connections racing a real unique
+ * constraint would.
+ */
+class FakeIdempotencyRepo {
+  rows: IdempotencyKey[] = [];
+  insertCalls = 0;
+  nextId = 1;
+
+  findOneBy(where: Partial<IdempotencyKey>): Promise<IdempotencyKey | null> {
+    return Promise.resolve(this.rows.find((r) => matches(r, where)) ?? null);
+  }
+
+  insert(data: Partial<IdempotencyKey>): Promise<void> {
+    this.insertCalls += 1;
+    const collision = this.rows.some(
+      (r) =>
+        r.key === data.key &&
+        r.scope === data.scope &&
+        r.callerId === data.callerId,
+    );
+    if (collision) {
+      return Promise.reject(uniqueViolationError());
+    }
+    const row = {
+      id: `row-${this.nextId++}`,
+      key: data.key,
+      scope: data.scope,
+      callerId: data.callerId,
+      status: IdempotencyKeyStatus.PROCESSING,
+      responseStatus: null,
+      responseBody: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      expiresAt: data.expiresAt,
+    } as IdempotencyKey;
+    this.rows.push(row);
+    return Promise.resolve();
+  }
+
+  update(
+    criteria: Partial<IdempotencyKey>,
+    partial: Partial<IdempotencyKey>,
+  ): Promise<{ affected: number }> {
+    let affected = 0;
+    for (const row of this.rows) {
+      if (matches(row, criteria)) {
+        Object.assign(row, partial);
+        affected += 1;
+      }
+    }
+    return Promise.resolve({ affected });
+  }
+
+  delete(criteria: Partial<IdempotencyKey>): Promise<{ affected: number }> {
+    const before = this.rows.length;
+    this.rows = this.rows.filter((r) => !matches(r, criteria));
+    return Promise.resolve({ affected: before - this.rows.length });
+  }
+}
+
+const DUMMY_HANDLER = function dummyHandler() {};
+
+function createContext(
+  overrides: {
+    headers?: Record<string, string>;
+    method?: string;
+    user?: { userId: string };
+  } = {},
+): ExecutionContext {
+  const request = {
+    headers: overrides.headers ?? {},
+    method: overrides.method ?? 'POST',
+    user: overrides.user,
+  };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => ({}),
+    }),
+    getHandler: () => DUMMY_HANDLER,
+  } as unknown as ExecutionContext;
+}
+
+function createNext(
+  factory: () => ReturnType<CallHandler['handle']>,
+): CallHandler & { handle: jest.Mock } {
+  return { handle: jest.fn(factory) };
+}
+
+function createReflector(scope: string | undefined): { get: jest.Mock } {
+  return {
+    get: jest.fn((key: string) =>
+      key === IDEMPOTENCY_SCOPE_KEY ? scope : undefined,
+    ),
+  };
+}
+
+const KEY_A = '11111111-1111-4111-8111-111111111111';
+const KEY_B = '22222222-2222-4222-8222-222222222222';
+
+describe('IdempotencyInterceptor', () => {
+  let repo: FakeIdempotencyRepo;
+  let reflector: { get: jest.Mock };
+  let interceptor: IdempotencyInterceptor;
+
+  beforeEach(() => {
+    repo = new FakeIdempotencyRepo();
+    reflector = createReflector('test.scope');
+    interceptor = new IdempotencyInterceptor(repo as never, reflector as never);
+  });
+
+  it('passes through untouched when the route carries no idempotency scope', async () => {
+    reflector = createReflector(undefined);
+    interceptor = new IdempotencyInterceptor(repo as never, reflector as never);
+    const next = createNext(() => of({ ok: true }));
+    const context = createContext();
+
+    const result = await lastValueFrom(
+      await interceptor.intercept(context, next),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    expect(repo.insertCalls).toBe(0);
+  });
+
+  it('rejects with 400 when the Idempotency-Key header is missing', async () => {
+    const next = createNext(() => of({ ok: true }));
+    const context = createContext({ headers: {} });
+
+    await expect(interceptor.intercept(context, next)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(next.handle).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 400 when the Idempotency-Key header is not a UUID', async () => {
+    const next = createNext(() => of({ ok: true }));
+    const context = createContext({ headers: { 'idempotency-key': 'nope' } });
+
+    await expect(interceptor.intercept(context, next)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(next.handle).not.toHaveBeenCalled();
+  });
+
+  it('executes the handler once and caches the result on first use', async () => {
+    const next = createNext(() => of({ id: 'bounty-1', status: 'funded' }));
+    const context = createContext({ headers: { 'idempotency-key': KEY_A } });
+
+    const observable = await interceptor.intercept(context, next);
+    const result = await lastValueFrom(observable);
+
+    expect(result).toEqual({ id: 'bounty-1', status: 'funded' });
+    expect(next.handle).toHaveBeenCalledTimes(1);
+
+    const row = repo.rows[0];
+    expect(row.status).toBe(IdempotencyKeyStatus.COMPLETED);
+    expect(row.responseBody).toEqual({ id: 'bounty-1', status: 'funded' });
+  });
+
+  it('replays the cached response on a duplicate key without re-executing the handler', async () => {
+    const next = createNext(() => of({ id: 'bounty-1', status: 'funded' }));
+    const context = createContext({ headers: { 'idempotency-key': KEY_A } });
+
+    await lastValueFrom(await interceptor.intercept(context, next));
+    const secondResult = await lastValueFrom(
+      await interceptor.intercept(context, next),
+    );
+
+    expect(secondResult).toEqual({ id: 'bounty-1', status: 'funded' });
+    expect(next.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes independently for different keys', async () => {
+    const next = createNext(() => of({ ok: true }));
+    const contextA = createContext({ headers: { 'idempotency-key': KEY_A } });
+    const contextB = createContext({ headers: { 'idempotency-key': KEY_B } });
+
+    await lastValueFrom(await interceptor.intercept(contextA, next));
+    await lastValueFrom(await interceptor.intercept(contextB, next));
+
+    expect(next.handle).toHaveBeenCalledTimes(2);
+    expect(repo.rows).toHaveLength(2);
+  });
+
+  it('does not cache a 5xx outcome, so a retry re-executes the handler', async () => {
+    let calls = 0;
+    const next = createNext(() => {
+      calls += 1;
+      if (calls === 1) {
+        return throwError(() => new InternalServerErrorException('boom'));
+      }
+      return of({ ok: true });
+    });
+    const context = createContext({ headers: { 'idempotency-key': KEY_A } });
+
+    await expect(
+      firstValueFrom(await interceptor.intercept(context, next)),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+    expect(repo.rows).toHaveLength(0);
+
+    const retryResult = await lastValueFrom(
+      await interceptor.intercept(context, next),
+    );
+
+    expect(retryResult).toEqual({ ok: true });
+    expect(next.handle).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches a 4xx outcome and replays the same exception on retry without re-executing', async () => {
+    const next = createNext(() =>
+      throwError(() => new BadRequestException('insufficient funds')),
+    );
+    const context = createContext({ headers: { 'idempotency-key': KEY_A } });
+
+    await expect(
+      firstValueFrom(await interceptor.intercept(context, next)),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repo.rows).toHaveLength(1);
+    expect(repo.rows[0].status).toBe(IdempotencyKeyStatus.COMPLETED);
+
+    await expect(interceptor.intercept(context, next)).rejects.toMatchObject({
+      status: 400,
+      response: { message: 'insufficient funds' },
+    });
+    expect(next.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a concurrent duplicate-key request with 409 and only executes the handler once', async () => {
+    const next = createNext(() => of({ ok: true }));
+    const context = createContext({ headers: { 'idempotency-key': KEY_A } });
+
+    const first = interceptor.intercept(context, next);
+    const second = interceptor.intercept(context, next);
+
+    const [firstOutcome, secondOutcome] = await Promise.allSettled([
+      first,
+      second,
+    ]);
+
+    expect(firstOutcome.status).toBe('fulfilled');
+    expect(secondOutcome.status).toBe('rejected');
+    if (secondOutcome.status === 'rejected') {
+      expect(secondOutcome.reason).toBeInstanceOf(ConflictException);
+    }
+    if (firstOutcome.status === 'fulfilled') {
+      await lastValueFrom(firstOutcome.value);
+    }
+
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    expect(repo.rows).toHaveLength(1);
+  });
+
+  it('reclaims a stale PROCESSING row instead of 409-ing forever', async () => {
+    const context = createContext({ headers: { 'idempotency-key': KEY_A } });
+    await repo.insert({
+      key: KEY_A,
+      scope: 'test.scope',
+      callerId: 'anonymous',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    // Simulate the original request having crashed mid-handler: back-date
+    // updatedAt past the staleness threshold instead of it being a
+    // genuinely in-flight request.
+    repo.rows[0].updatedAt = new Date(Date.now() - STALE_PROCESSING_MS - 1);
+
+    const next = createNext(() => of({ ok: true, reclaimed: true }));
+    const result = await lastValueFrom(
+      await interceptor.intercept(context, next),
+    );
+
+    expect(result).toEqual({ ok: true, reclaimed: true });
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    expect(repo.rows[0].status).toBe(IdempotencyKeyStatus.COMPLETED);
+  });
+
+  it('rejects with 409 while a PROCESSING row is still fresh', async () => {
+    const context = createContext({ headers: { 'idempotency-key': KEY_A } });
+    await repo.insert({
+      key: KEY_A,
+      scope: 'test.scope',
+      callerId: 'anonymous',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const next = createNext(() => of({ ok: true }));
+
+    await expect(interceptor.intercept(context, next)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+    expect(next.handle).not.toHaveBeenCalled();
+  });
+
+  it('scopes keys per authenticated caller when req.user is present', async () => {
+    const next = createNext(() => of({ ok: true }));
+    const contextUser1 = createContext({
+      headers: { 'idempotency-key': KEY_A },
+      user: { userId: 'user-1' },
+    });
+    const contextUser2 = createContext({
+      headers: { 'idempotency-key': KEY_A },
+      user: { userId: 'user-2' },
+    });
+
+    await lastValueFrom(await interceptor.intercept(contextUser1, next));
+    await lastValueFrom(await interceptor.intercept(contextUser2, next));
+
+    expect(next.handle).toHaveBeenCalledTimes(2);
+    expect(repo.rows.map((r) => r.callerId).sort()).toEqual([
+      'user-1',
+      'user-2',
+    ]);
+  });
+});

--- a/src/common/idempotency/idempotency.interceptor.ts
+++ b/src/common/idempotency/idempotency.interceptor.ts
@@ -232,18 +232,14 @@ export class IdempotencyInterceptor implements NestInterceptor {
     // id *and* the exact `updatedAt` we observed makes this an atomic
     // compare-and-swap, so if two retries race to reclaim the same stale
     // row, only one UPDATE matches and wins.
-    const reclaim = await this.repo
-      .createQueryBuilder()
-      .update(IdempotencyKey)
-      .set({ updatedAt: new Date() })
-      .where('id = :id', { id: existing.id })
-      .andWhere('status = :status', {
+    const reclaim = await this.repo.update(
+      {
+        id: existing.id,
         status: IdempotencyKeyStatus.PROCESSING,
-      })
-      .andWhere('"updatedAt" = :observedUpdatedAt', {
-        observedUpdatedAt: existing.updatedAt,
-      })
-      .execute();
+        updatedAt: existing.updatedAt,
+      },
+      { updatedAt: new Date() },
+    );
 
     if ((reclaim.affected ?? 0) > 0) {
       return null;

--- a/src/common/idempotency/idempotency.interceptor.ts
+++ b/src/common/idempotency/idempotency.interceptor.ts
@@ -1,0 +1,294 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { HTTP_CODE_METADATA } from '@nestjs/common/constants';
+import { Reflector } from '@nestjs/core';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { Request } from 'express';
+import { from, Observable, of, throwError } from 'rxjs';
+import { catchError, map, mergeMap } from 'rxjs/operators';
+import { Repository } from 'typeorm';
+import type { QueryDeepPartialEntity } from 'typeorm';
+import { IdempotencyKey, JsonValue } from '../entities/idempotency-key.entity';
+import { IdempotencyKeyStatus } from '../enums';
+import { IDEMPOTENCY_SCOPE_KEY } from './idempotent.decorator';
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * How long a completed key's cached response stays replayable for. Chosen
+ * to comfortably outlast any plausible client retry/backoff window without
+ * keeping rows around indefinitely; actual deletion is performed by
+ * IdempotencyCleanupService's sweep once `expiresAt` passes.
+ */
+export const IDEMPOTENCY_KEY_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * A PROCESSING row older than this is treated as abandoned (the process
+ * handling it almost certainly crashed rather than being merely slow) and
+ * is reclaimed by the next request instead of permanently 409-ing.
+ */
+const STALE_PROCESSING_MS = 30 * 1000;
+
+/** Postgres SQLSTATE for unique_violation. */
+const PG_UNIQUE_VIOLATION = '23505';
+
+function isUniqueViolation(error: unknown): boolean {
+  const driverError = (error as { driverError?: { code?: string } } | null)
+    ?.driverError;
+  return driverError?.code === PG_UNIQUE_VIOLATION;
+}
+
+interface KeyIdentity {
+  key: string;
+  scope: string;
+  callerId: string;
+}
+
+interface CachedOutcome {
+  responseStatus: number;
+  responseBody: JsonValue;
+}
+
+/**
+ * Backs the `@Idempotent(scope)` decorator (#16).
+ *
+ * The safety property this provides — two concurrent requests carrying the
+ * same Idempotency-Key/scope/caller never both execute the underlying
+ * mutation — comes entirely from `idempotency_keys`' unique index on
+ * (key, scope, callerId), not from anything in this class. `claim()` always
+ * *attempts* a plain `insert()` and reacts to a unique-violation rather than
+ * checking-then-inserting, because a JS-level "does a row exist?" check
+ * followed by a separate insert has the same TOCTOU gap the issue warns
+ * about — the database constraint is what actually closes it.
+ *
+ * Response caching policy: a 2xx or 4xx outcome is a definite, deterministic
+ * result of the request, so it's cached and replayed verbatim on retry. A
+ * 5xx (or any non-HttpException failure) is *not* cached — the key is
+ * released instead — because forcing every future retry to replay a server
+ * error forever is worse than letting the retry try again cleanly.
+ *
+ * Caller scoping: none of the controllers this guards (bounties, escrow,
+ * milestones, maintenance-pool) currently sit behind JwtAuthGuard, so there
+ * is no authenticated caller to scope by yet. `resolveCallerId` falls back
+ * to a shared 'anonymous' bucket per scope in that case — see its doc
+ * comment for what that does and doesn't protect against.
+ */
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(
+    @InjectRepository(IdempotencyKey)
+    private readonly repo: Repository<IdempotencyKey>,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<unknown>> {
+    const scope = this.reflector.get<string | undefined>(
+      IDEMPOTENCY_SCOPE_KEY,
+      context.getHandler(),
+    );
+    if (!scope) {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const rawKey = request.headers['idempotency-key'];
+    const key = Array.isArray(rawKey) ? rawKey[0] : rawKey;
+
+    if (!key || !UUID_PATTERN.test(key)) {
+      throw new BadRequestException(
+        'A valid Idempotency-Key header (UUID) is required for this request',
+      );
+    }
+
+    const identity: KeyIdentity = {
+      key,
+      scope,
+      callerId: this.resolveCallerId(request),
+    };
+
+    const cached = await this.claim(identity);
+    if (cached) {
+      const badRequestStatus: number = HttpStatus.BAD_REQUEST;
+      if (cached.responseStatus >= badRequestStatus) {
+        throw new HttpException(
+          cached.responseBody as string | Record<string, unknown>,
+          cached.responseStatus,
+        );
+      }
+      return of(cached.responseBody);
+    }
+
+    // Mirrors Nest's own status resolution (explicit @HttpCode(), else 201
+    // for POST / 200 otherwise) purely so the cached row records the status
+    // the caller actually saw — it doesn't influence what Nest sends now,
+    // since that's independently recomputed by Nest from the same route
+    // metadata on every request, replay or not.
+    const httpStatusCode =
+      this.reflector.get<number | undefined>(
+        HTTP_CODE_METADATA,
+        context.getHandler(),
+      ) ?? (request.method === 'POST' ? HttpStatus.CREATED : HttpStatus.OK);
+
+    return next.handle().pipe(
+      mergeMap((data: unknown) =>
+        from(
+          this.complete(identity, {
+            responseStatus: httpStatusCode,
+            responseBody: (data ?? null) as JsonValue,
+          }),
+        ).pipe(map(() => data)),
+      ),
+      catchError((error: unknown) =>
+        from(this.settleFailure(identity, error)).pipe(
+          mergeMap(() => throwError(() => error)),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Determines the bucket a key is scoped to. `req.user.userId` is used
+   * when the route is authenticated (none of the current target routes
+   * are — see class doc comment). The 'anonymous' fallback still gives
+   * correct duplicate-suppression and concurrency-safety for a single
+   * client retrying its own request, since that's driven entirely by the
+   * (key, scope, callerId) uniqueness, not by callerId being a *real*
+   * per-user identity — it just means two different anonymous callers
+   * *could* collide if they both independently generated the same UUID
+   * for the same scope, which is the accepted, documented trade-off until
+   * these routes require auth.
+   */
+  private resolveCallerId(request: Request): string {
+    const user = (request as Request & { user?: { userId?: string } }).user;
+    return user?.userId ?? 'anonymous';
+  }
+
+  /**
+   * Returns a cached outcome to replay, or null if this call has become
+   * the owner of the key and should proceed with the real handler.
+   * Throws ConflictException (409) if another request currently owns it.
+   */
+  private async claim(identity: KeyIdentity): Promise<CachedOutcome | null> {
+    const existing = await this.repo.findOneBy(identity);
+    if (existing) {
+      return this.resolveExisting(existing, identity);
+    }
+
+    try {
+      await this.repo.insert({
+        ...identity,
+        expiresAt: new Date(Date.now() + IDEMPOTENCY_KEY_TTL_MS),
+      });
+      return null;
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
+      // Lost the insert race — another request became the owner between
+      // our findOneBy and our insert. Defer to it exactly as if we'd
+      // found it up front.
+      const winner = await this.repo.findOneBy(identity);
+      if (!winner) {
+        // The winner's row is already gone (e.g. it failed with a 5xx and
+        // was released in the instant between our failed insert and this
+        // read) — safe to treat this as a fresh attempt.
+        return null;
+      }
+      return this.resolveExisting(winner, identity);
+    }
+  }
+
+  private async resolveExisting(
+    existing: IdempotencyKey,
+    identity: KeyIdentity,
+  ): Promise<CachedOutcome | null> {
+    if (existing.status === IdempotencyKeyStatus.COMPLETED) {
+      return {
+        responseStatus: existing.responseStatus ?? HttpStatus.OK,
+        responseBody: existing.responseBody,
+      };
+    }
+
+    const ageMs = Date.now() - existing.updatedAt.getTime();
+    if (ageMs < STALE_PROCESSING_MS) {
+      throw new ConflictException(
+        'A request with this Idempotency-Key is already being processed',
+      );
+    }
+
+    // Reclaim a stale PROCESSING row: conditioning the UPDATE on both the
+    // id *and* the exact `updatedAt` we observed makes this an atomic
+    // compare-and-swap, so if two retries race to reclaim the same stale
+    // row, only one UPDATE matches and wins.
+    const reclaim = await this.repo
+      .createQueryBuilder()
+      .update(IdempotencyKey)
+      .set({ updatedAt: new Date() })
+      .where('id = :id', { id: existing.id })
+      .andWhere('status = :status', {
+        status: IdempotencyKeyStatus.PROCESSING,
+      })
+      .andWhere('"updatedAt" = :observedUpdatedAt', {
+        observedUpdatedAt: existing.updatedAt,
+      })
+      .execute();
+
+    if ((reclaim.affected ?? 0) > 0) {
+      return null;
+    }
+
+    // Someone else reclaimed or completed it first — read back the current
+    // state and defer to it rather than assuming.
+    const current = await this.repo.findOneBy(identity);
+    if (!current) {
+      return null;
+    }
+    return this.resolveExisting(current, identity);
+  }
+
+  private async complete(
+    identity: KeyIdentity,
+    outcome: CachedOutcome,
+  ): Promise<void> {
+    await this.repo.update(identity, {
+      status: IdempotencyKeyStatus.COMPLETED,
+      responseStatus: outcome.responseStatus,
+      responseBody: outcome.responseBody,
+    } as QueryDeepPartialEntity<IdempotencyKey>);
+  }
+
+  private async settleFailure(
+    identity: KeyIdentity,
+    error: unknown,
+  ): Promise<void> {
+    if (error instanceof HttpException) {
+      const status = error.getStatus();
+      const internalServerErrorStatus: number =
+        HttpStatus.INTERNAL_SERVER_ERROR;
+      if (status < internalServerErrorStatus) {
+        await this.repo.update(identity, {
+          status: IdempotencyKeyStatus.COMPLETED,
+          responseStatus: status,
+          responseBody: error.getResponse(),
+        });
+        return;
+      }
+    }
+
+    // Not a safe, deterministic outcome to force every future retry to
+    // replay — release the key so the next attempt re-executes cleanly.
+    await this.repo.delete(identity);
+  }
+}

--- a/src/common/idempotency/idempotency.module.ts
+++ b/src/common/idempotency/idempotency.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IdempotencyKey } from '../entities/idempotency-key.entity';
+import { IdempotencyCleanupService } from './idempotency-cleanup.service';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+/**
+ * Global so `@Idempotent(scope)` (which references IdempotencyInterceptor
+ * by class, not instance) resolves from any feature module's controllers
+ * without each of them having to import this module individually — see
+ * bounties/escrow/milestones/maintenance-pool controllers (#16).
+ */
+@Global()
+@Module({
+  imports: [TypeOrmModule.forFeature([IdempotencyKey])],
+  providers: [IdempotencyInterceptor, IdempotencyCleanupService],
+  exports: [IdempotencyInterceptor],
+})
+export class IdempotencyModule {}

--- a/src/common/idempotency/idempotent.decorator.ts
+++ b/src/common/idempotency/idempotent.decorator.ts
@@ -1,0 +1,28 @@
+import { applyDecorators, SetMetadata, UseInterceptors } from '@nestjs/common';
+import { ApiHeader } from '@nestjs/swagger';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+export const IDEMPOTENCY_SCOPE_KEY = 'idempotency:scope';
+
+/**
+ * Marks a mutation endpoint as requiring an `Idempotency-Key` header and
+ * guards it with IdempotencyInterceptor (#16).
+ *
+ * `scope` namespaces keys per endpoint (e.g. 'bounty.fund') — the same key
+ * value reused across two different scopes is treated as two unrelated
+ * requests, since a client legitimately reusing a UUID generator's output
+ * across different calls shouldn't collide.
+ */
+export function Idempotent(scope: string) {
+  return applyDecorators(
+    SetMetadata(IDEMPOTENCY_SCOPE_KEY, scope),
+    UseInterceptors(IdempotencyInterceptor),
+    ApiHeader({
+      name: 'Idempotency-Key',
+      required: true,
+      description:
+        'Client-supplied UUID identifying this request. Retrying the same request (same key, same endpoint, same caller) after a network failure returns the original response instead of re-executing the mutation. A concurrent request reusing an in-flight key receives 409 Conflict. Cached outcomes are retained for a limited time — see the API README/docs for the current TTL.',
+      schema: { type: 'string', format: 'uuid' },
+    }),
+  );
+}

--- a/src/database/migrations/1784304511000-CreateIdempotencyKeys.ts
+++ b/src/database/migrations/1784304511000-CreateIdempotencyKeys.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the idempotency_keys table backing the Idempotency-Key header
+ * support added in #16 — see IdempotencyKey (entity), IdempotencyInterceptor,
+ * and IdempotencyCleanupService.
+ */
+export class CreateIdempotencyKeys1784304511000 implements MigrationInterface {
+  name = 'CreateIdempotencyKeys1784304511000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "idempotency_keys_status_enum" AS ENUM ('processing', 'completed')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "idempotency_keys" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "key" character varying NOT NULL,
+        "scope" character varying NOT NULL,
+        "callerId" character varying NOT NULL,
+        "status" "idempotency_keys_status_enum" NOT NULL DEFAULT 'processing',
+        "responseStatus" integer,
+        "responseBody" jsonb,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "expiresAt" TIMESTAMPTZ NOT NULL,
+        CONSTRAINT "PK_idempotency_keys" PRIMARY KEY ("id")
+      )
+    `);
+
+    // The concurrency-safety primitive: see IdempotencyKey's doc comment.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_idempotency_keys_key_scope_callerId"
+      ON "idempotency_keys" ("key", "scope", "callerId")
+    `);
+
+    // Supports IdempotencyCleanupService's periodic DELETE ... WHERE
+    // "expiresAt" < now() sweep without a sequential scan.
+    await queryRunner.query(`
+      CREATE INDEX "IDX_idempotency_keys_expiresAt" ON "idempotency_keys" ("expiresAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_idempotency_keys_expiresAt"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_idempotency_keys_key_scope_callerId"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "idempotency_keys"`);
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "idempotency_keys_status_enum"`,
+    );
+  }
+}

--- a/src/escrow/escrow.controller.spec.ts
+++ b/src/escrow/escrow.controller.spec.ts
@@ -1,8 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { EscrowController } from './escrow.controller';
 import { EscrowService } from './escrow.service';
 import { AssetType, EscrowStatus } from '../common/enums';
 import { Escrow } from '../common/entities';
+import { IdempotencyKey } from '../common/entities/idempotency-key.entity';
+import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor';
 
 function makeEscrowWithLeakyMetadata(): Escrow {
   return {
@@ -56,7 +60,19 @@ describe('EscrowController (#19 metadata leak)', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EscrowController],
-      providers: [{ provide: EscrowService, useValue: escrowService }],
+      providers: [
+        { provide: EscrowService, useValue: escrowService },
+        // These endpoints carry @Idempotent, which resolves
+        // IdempotencyInterceptor via DI even though this suite calls
+        // controller methods directly and never runs the interceptor
+        // itself (#16).
+        IdempotencyInterceptor,
+        Reflector,
+        {
+          provide: getRepositoryToken(IdempotencyKey),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get(EscrowController);

--- a/src/escrow/escrow.controller.ts
+++ b/src/escrow/escrow.controller.ts
@@ -5,12 +5,14 @@ import { FundEscrowDto } from './dto/fund-escrow.dto';
 import { ReleaseEscrowDto } from './dto/release-escrow.dto';
 import { SplitReleaseDto } from './dto/split-release.dto';
 import { toPublicEscrow } from './escrow-response.mapper';
+import { Idempotent } from '../common/idempotency/idempotent.decorator';
 
 @ApiTags('escrow')
 @Controller('escrow')
 export class EscrowController {
   constructor(private readonly escrowService: EscrowService) {}
 
+  @Idempotent('escrow.fund')
   @Post('fund')
   async fund(@Body() dto: FundEscrowDto) {
     return toPublicEscrow(await this.escrowService.fund(dto));
@@ -21,6 +23,7 @@ export class EscrowController {
     return toPublicEscrow(await this.escrowService.findOne(id));
   }
 
+  @Idempotent('escrow.release')
   @Post(':id/release')
   async release(@Param('id') id: string, @Body() dto: ReleaseEscrowDto) {
     return toPublicEscrow(
@@ -32,11 +35,13 @@ export class EscrowController {
     );
   }
 
+  @Idempotent('escrow.splitRelease')
   @Post(':id/split-release')
   splitRelease(@Param('id') id: string, @Body() dto: SplitReleaseDto) {
     return this.escrowService.splitRelease(id, dto.recipients);
   }
 
+  @Idempotent('escrow.refund')
   @Post(':id/refund')
   async refund(@Param('id') id: string) {
     return toPublicEscrow(await this.escrowService.refund(id));

--- a/src/maintenance-pool/maintenance-pool.controller.ts
+++ b/src/maintenance-pool/maintenance-pool.controller.ts
@@ -4,6 +4,7 @@ import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { MaintenancePoolService } from './maintenance-pool.service';
 import { CreatePoolDto } from './dto/create-pool.dto';
 import { IsMoneyAmount } from '../common/validators/money.validator';
+import { Idempotent } from '../common/idempotency/idempotent.decorator';
 
 class DepositDto {
   @IsMoneyAmount()
@@ -45,11 +46,13 @@ export class MaintenancePoolController {
     return this.poolService.findOne(id);
   }
 
+  @Idempotent('pool.deposit')
   @Post(':id/deposit')
   deposit(@Param('id') id: string, @Body() dto: DepositDto) {
     return this.poolService.deposit(id, dto.amount, dto.funderAddress);
   }
 
+  @Idempotent('pool.assignReward')
   @Post(':id/assign-reward')
   assignReward(@Param('id') id: string, @Body() dto: AssignRewardDto) {
     return this.poolService.assignReward(

--- a/src/milestones/milestones.controller.ts
+++ b/src/milestones/milestones.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { MilestonesService } from './milestones.service';
 import { CreateMilestoneDto } from './dto/create-milestone.dto';
+import { Idempotent } from '../common/idempotency/idempotent.decorator';
 
 class FundMilestoneDto {
   @IsString()
@@ -38,6 +39,7 @@ export class MilestonesController {
     return this.milestonesService.findOne(id);
   }
 
+  @Idempotent('milestone.fund')
   @Post(':id/fund')
   fund(@Param('id') id: string, @Body() dto: FundMilestoneDto) {
     return this.milestonesService.fund(id, dto.funderAddress);
@@ -48,6 +50,7 @@ export class MilestonesController {
     return this.milestonesService.addIssue(id, issueId);
   }
 
+  @Idempotent('milestone.resolveIssue')
   @Post(':id/issues/:issueId/resolve')
   resolveIssue(
     @Param('id') id: string,


### PR DESCRIPTION
## Summary

Closes #16. Adds an `Idempotency-Key` header contract to every fund/claim/release/refund mutation across Bounties, Escrow, Milestones, and MaintenancePool, so a client retry after a dropped connection can't double-execute a mutation.

- **`IdempotencyKey` entity + migration** — new `idempotency_keys` table with a unique index on `(key, scope, callerId)`. This unique index is the actual concurrency-safety primitive: `IdempotencyInterceptor` always *attempts* a plain `insert()` and reacts to a unique-violation rather than checking-then-inserting, since a JS-level "does a row exist?" check followed by a separate insert has the exact same TOCTOU race the issue's difficulty justification warns about — the DB constraint is what actually closes it.
- **`@Idempotent(scope)` decorator** — applies `IdempotencyInterceptor` plus a Swagger `@ApiHeader` documenting the contract. Applied to `BountiesController.fund/claim/refund`, `EscrowController.fund/release/splitRelease/refund`, `MilestonesController.fund/resolveIssue`, `MaintenancePoolController.deposit/assignReward`.
- **Caching policy**: 2xx and 4xx outcomes are cached and replayed verbatim on retry. A 5xx (or any non-`HttpException` failure) is *not* cached — the key is released instead — since forcing every future retry to replay a server error forever is worse than letting the retry run cleanly.
- **Concurrency**: a request reusing a key that's still `PROCESSING` gets `409 Conflict`. A `PROCESSING` row older than 30s is assumed to belong to a crashed request and is reclaimed via an atomic compare-and-swap (`UPDATE ... WHERE id = :id AND status = 'processing' AND updatedAt = :observed`), so two retries racing to reclaim the same stale row only let one through.
- **TTL/cleanup**: completed keys are retained for 24h (`IDEMPOTENCY_KEY_TTL_MS`) and swept hourly by `IdempotencyCleanupService` (`@nestjs/schedule`). Documented in the README's new "Idempotency" section.
- **Caller scoping**: none of the four target controllers currently sit behind `JwtAuthGuard`. `resolveCallerId` uses `req.user.userId` when present and falls back to a shared `'anonymous'` bucket otherwise — documented as a known, accepted trade-off in the interceptor's doc comment rather than silently expanding scope by adding auth to these routes.

## Test plan

- [x] `IdempotencyInterceptor` unit tests (`idempotency.interceptor.spec.ts`): missing/invalid header → 400; first call executes the handler and caches the result; duplicate key replays the cached result without re-executing (spy call count); two *genuinely concurrent* same-key requests interleaved via real Promise/microtask racing against an in-memory unique-index stand-in — only one executes, the other gets 409; different keys execute independently; 5xx is not cached (retry re-executes); 4xx is cached and replayed as the same exception; stale `PROCESSING` row is reclaimed instead of 409-ing forever; caller scoping via `req.user.userId`.
- [x] `IdempotencyCleanupService` unit tests: sweeps rows past `expiresAt`.
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run build` all pass.
- [x] `npx jest` — all suites pass except the pre-existing `*.integration.spec.ts` files that require a live Postgres connection (not available in this environment; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)