### PR TITLE
feat: rate-limit-aware, resumable GitHub sync with webhook race guard (#24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@nestjs/swagger": "^11.4.5",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.3",
+        "@octokit/plugin-retry": "^8.1.0",
+        "@octokit/plugin-throttling": "^11.0.3",
         "@octokit/rest": "^22.0.1",
         "@stellar/stellar-sdk": "^16.0.1",
         "class-transformer": "^0.5.1",
@@ -2785,6 +2787,39 @@
         "@octokit/core": ">=6"
       }
     },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
+      "integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
+      "integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
+      }
+    },
     "node_modules/@octokit/request": {
       "version": "10.0.11",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
@@ -4778,6 +4813,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@nestjs/swagger": "^11.4.5",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.3",
+    "@octokit/plugin-retry": "^8.1.0",
+    "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
     "@stellar/stellar-sdk": "^16.0.1",
     "class-transformer": "^0.5.1",
@@ -97,6 +99,9 @@
     "moduleNameMapper": {
       "^@stellar/stellar-sdk$": "<rootDir>/../test/mocks/stellar-sdk.mock.js"
     },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(@octokit|before-after-hook|universal-user-agent)/)"
+    ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/common/entities/issue.entity.ts
+++ b/src/common/entities/issue.entity.ts
@@ -70,6 +70,18 @@ export class Issue {
   @Column({ type: 'timestamptz', nullable: true })
   closedAt: Date | null;
 
+  /**
+   * GitHub's own `updated_at` for this issue, as of the last write that
+   * touched it (from either sync or a webhook). Sync and the `issues`
+   * webhook handler both write through the same optimistic-concurrency
+   * guard in GithubSyncService: a write is only applied if its incoming
+   * `updated_at` is >= this value, so whichever source has the freshest
+   * GitHub-side data always wins regardless of which one happens to run
+   * or commit second — see #24.
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  githubUpdatedAt: Date | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/database/migrations/1784400000000-AddIssueGithubUpdatedAt.ts
+++ b/src/database/migrations/1784400000000-AddIssueGithubUpdatedAt.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds Issue.githubUpdatedAt — GitHub's own `updated_at` for the issue, used
+ * by GithubSyncService's optimistic-concurrency guard (#24) to stop a sync
+ * from clobbering a newer webhook-driven update (or vice versa).
+ */
+export class AddIssueGithubUpdatedAt1784400000000 implements MigrationInterface {
+  name = 'AddIssueGithubUpdatedAt1784400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "issues"
+      ADD COLUMN "githubUpdatedAt" TIMESTAMPTZ
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "issues"
+      DROP COLUMN "githubUpdatedAt"
+    `);
+  }
+}

--- a/src/github/github-sync.service.spec.ts
+++ b/src/github/github-sync.service.spec.ts
@@ -1,0 +1,371 @@
+import { Logger } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Issue, Repository } from '../common/entities';
+import {
+  GithubSyncInterruptedError,
+  GithubSyncService,
+  RawGithubIssue,
+} from './github-sync.service';
+import { GITHUB_OCTOKIT } from './octokit.provider';
+
+function issuePage(items: Array<Partial<RawGithubIssue>>) {
+  return {
+    data: items.map((item) => ({
+      id: 1,
+      number: 1,
+      title: 'untitled',
+      state: 'open',
+      html_url: 'https://github.com/a/b/issues/1',
+      updated_at: '2026-01-01T00:00:00Z',
+      ...item,
+    })),
+  };
+}
+
+/**
+ * Mimics `octokit.paginate.iterator`'s async-generator contract. A plain
+ * (non-async) generator satisfies `for await...of` just as well when there's
+ * nothing to actually await between yields.
+ */
+function* pagesThenThrow(
+  pages: Array<ReturnType<typeof issuePage>>,
+  error?: Error,
+) {
+  for (const page of pages) {
+    yield page;
+  }
+  if (error) throw error;
+}
+
+describe('GithubSyncService', () => {
+  let service: GithubSyncService;
+  let octokit: {
+    repos: { get: jest.Mock };
+    pulls: { get: jest.Mock };
+    issues: { listForRepo: jest.Mock };
+    paginate: { iterator: jest.Mock };
+    rest: { rateLimit: { get: jest.Mock } };
+  };
+  let repositoryRepo: {
+    findOne: jest.Mock;
+    merge: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+  let issueRepo: {
+    findOne: jest.Mock;
+    merge: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    octokit = {
+      repos: { get: jest.fn() },
+      pulls: { get: jest.fn() },
+      issues: { listForRepo: jest.fn() },
+      paginate: { iterator: jest.fn() },
+      rest: { rateLimit: { get: jest.fn() } },
+    };
+    repositoryRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      merge: jest.fn((existing: object, attrs: Record<string, unknown>) => ({
+        ...existing,
+        ...attrs,
+      })),
+      create: jest.fn((attrs: Record<string, unknown>) => ({
+        id: 'repo-1',
+        ...attrs,
+      })),
+      save: jest.fn((repo: object) => Promise.resolve(repo)),
+    };
+    issueRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      merge: jest.fn((existing: object, attrs: Record<string, unknown>) => ({
+        ...existing,
+        ...attrs,
+      })),
+      create: jest.fn((attrs: Record<string, unknown>) => ({
+        id: `issue-${String(attrs.githubIssueId)}`,
+        ...attrs,
+      })),
+      save: jest.fn((issue: object) => Promise.resolve(issue)),
+    };
+
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    octokit.rest.rateLimit.get.mockResolvedValue({
+      data: {
+        resources: {
+          core: { limit: 5000, remaining: 4999, reset: 1234567890 },
+        },
+      },
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GithubSyncService,
+        { provide: GITHUB_OCTOKIT, useValue: octokit },
+        { provide: getRepositoryToken(Repository), useValue: repositoryRepo },
+        { provide: getRepositoryToken(Issue), useValue: issueRepo },
+      ],
+    }).compile();
+
+    service = module.get(GithubSyncService);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe('syncIssues', () => {
+    it('persists issues page by page and skips pull requests', async () => {
+      octokit.paginate.iterator.mockReturnValue(
+        pagesThenThrow([
+          issuePage([
+            {
+              id: 1,
+              number: 1,
+              title: 'Issue one',
+              updated_at: '2026-01-01T00:00:00Z',
+            },
+            { id: 2, number: 2, title: 'A PR', pull_request: {} },
+          ]),
+          issuePage([
+            {
+              id: 3,
+              number: 3,
+              title: 'Issue three',
+              updated_at: '2026-01-02T00:00:00Z',
+            },
+          ]),
+        ]),
+      );
+
+      const repository = { id: 'repo-1' } as Repository;
+      const saved = await service.syncIssues(repository, 'acme', 'widgets');
+
+      expect(saved).toHaveLength(2);
+      expect(saved.map((i) => i.title)).toEqual(['Issue one', 'Issue three']);
+      expect(issueRepo.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('never persists issues that carry pull_request', async () => {
+      octokit.paginate.iterator.mockReturnValue(
+        pagesThenThrow([
+          issuePage([{ id: 9, number: 9, pull_request: { url: 'x' } }]),
+        ]),
+      );
+
+      const saved = await service.syncIssues(
+        { id: 'repo-1' } as Repository,
+        'acme',
+        'widgets',
+      );
+      expect(saved).toHaveLength(0);
+      expect(issueRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('keeps issues already persisted before a mid-pagination failure, and reports a resumable error', async () => {
+      const rateLimitError = Object.assign(
+        new Error('API rate limit exceeded'),
+        {
+          status: 429,
+        },
+      );
+
+      octokit.paginate.iterator.mockReturnValue(
+        pagesThenThrow(
+          [
+            issuePage([
+              { id: 1, number: 1, title: 'Persisted before failure' },
+            ]),
+          ],
+          rateLimitError,
+        ),
+      );
+
+      await expect(
+        service.syncIssues({ id: 'repo-1' } as Repository, 'acme', 'widgets'),
+      ).rejects.toThrow(GithubSyncInterruptedError);
+
+      // The page fetched before the 429 is durably saved, not discarded.
+      expect(issueRepo.save).toHaveBeenCalledTimes(1);
+      expect(issueRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Persisted before failure' }),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('interrupted'),
+      );
+    });
+
+    it('the thrown error clearly reports how many issues survived and that re-running is safe', async () => {
+      const networkError = new Error('ECONNRESET');
+      octokit.paginate.iterator.mockReturnValue(
+        pagesThenThrow(
+          [
+            issuePage([{ id: 1, number: 1 }]),
+            issuePage([{ id: 2, number: 2 }]),
+          ],
+          networkError,
+        ),
+      );
+
+      let caught: GithubSyncInterruptedError | undefined;
+      try {
+        await service.syncIssues(
+          { id: 'repo-1' } as Repository,
+          'acme',
+          'widgets',
+        );
+      } catch (err) {
+        caught = err as GithubSyncInterruptedError;
+      }
+
+      expect(caught).toBeInstanceOf(GithubSyncInterruptedError);
+      expect(caught?.issuesSyncedBeforeFailure).toBe(2);
+      expect(caught?.owner).toBe('acme');
+      expect(caught?.repo).toBe('widgets');
+      expect(caught?.message).toMatch(/safe to re-run|re-run the sync/i);
+    });
+  });
+
+  describe('upsertIssueRecord — optimistic concurrency (#24)', () => {
+    it('applies a write when there is no existing record', async () => {
+      issueRepo.findOne.mockResolvedValue(null);
+      const { applied } = await service.upsertIssueRecord('repo-1', {
+        id: 1,
+        number: 1,
+        title: 'New issue',
+        state: 'open',
+        html_url: 'x',
+        updated_at: '2026-01-01T00:00:00Z',
+      });
+      expect(applied).toBe(true);
+      expect(issueRepo.save).toHaveBeenCalled();
+    });
+
+    it('rejects a stale write that arrives after a newer one, regardless of call order (sync after webhook)', async () => {
+      const newer = new Date('2026-01-05T00:00:00Z');
+      issueRepo.findOne.mockResolvedValue({
+        id: 'issue-1',
+        githubIssueId: '1',
+        githubUpdatedAt: newer,
+      });
+
+      const { applied } = await service.upsertIssueRecord('repo-1', {
+        id: 1,
+        number: 1,
+        title: 'Stale sync payload',
+        state: 'open',
+        html_url: 'x',
+        updated_at: '2026-01-01T00:00:00Z', // older than `newer`
+      });
+
+      expect(applied).toBe(false);
+      expect(issueRepo.save).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping stale write'),
+      );
+    });
+
+    it('rejects a stale write that arrives after a newer one, regardless of call order (webhook after sync)', async () => {
+      const newer = new Date('2026-02-01T00:00:00Z');
+      issueRepo.findOne.mockResolvedValue({
+        id: 'issue-1',
+        githubIssueId: '1',
+        githubUpdatedAt: newer,
+      });
+
+      const { applied } = await service.upsertIssueRecord('repo-1', {
+        id: 1,
+        number: 1,
+        title: 'Delayed stale webhook retry',
+        state: 'open',
+        html_url: 'x',
+        updated_at: '2026-01-15T00:00:00Z', // older than `newer`
+      });
+
+      expect(applied).toBe(false);
+      expect(issueRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('applies a write that is newer than the stored record', async () => {
+      issueRepo.findOne.mockResolvedValue({
+        id: 'issue-1',
+        githubIssueId: '1',
+        githubUpdatedAt: new Date('2026-01-01T00:00:00Z'),
+      });
+
+      const { applied } = await service.upsertIssueRecord('repo-1', {
+        id: 1,
+        number: 1,
+        title: 'Fresh update',
+        state: 'closed',
+        html_url: 'x',
+        updated_at: '2026-01-10T00:00:00Z',
+      });
+
+      expect(applied).toBe(true);
+      expect(issueRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Fresh update', state: 'closed' }),
+      );
+    });
+  });
+
+  describe('syncRepository — rate-limit budget logging (#24)', () => {
+    it('logs rate-limit status before and after a sync', async () => {
+      octokit.repos.get.mockResolvedValue({
+        data: {
+          id: 42,
+          owner: { login: 'acme' },
+          name: 'widgets',
+          full_name: 'acme/widgets',
+          default_branch: 'main',
+          private: false,
+        },
+      });
+      octokit.paginate.iterator.mockReturnValue(
+        pagesThenThrow([issuePage([])]),
+      );
+
+      await service.syncRepository('acme', 'widgets');
+
+      const rateLimitLogs = (logSpy.mock.calls as unknown[][])
+        .map((call) => String(call[0]))
+        .filter((msg) => msg.includes('rate-limit'));
+      expect(rateLimitLogs.some((m) => m.includes('before'))).toBe(true);
+      expect(rateLimitLogs.some((m) => m.includes('after'))).toBe(true);
+      expect(octokit.rest.rateLimit.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not let a rate-limit status lookup failure block the sync itself', async () => {
+      octokit.rest.rateLimit.get.mockRejectedValue(new Error('unreachable'));
+      octokit.repos.get.mockResolvedValue({
+        data: {
+          id: 42,
+          owner: { login: 'acme' },
+          name: 'widgets',
+          full_name: 'acme/widgets',
+          default_branch: 'main',
+          private: false,
+        },
+      });
+      octokit.paginate.iterator.mockReturnValue(
+        pagesThenThrow([issuePage([])]),
+      );
+
+      await expect(
+        service.syncRepository('acme', 'widgets'),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/src/github/github-sync.service.ts
+++ b/src/github/github-sync.service.ts
@@ -1,15 +1,66 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Octokit } from '@octokit/rest';
 import { Repository as TypeOrmRepository } from 'typeorm';
 import { Issue, Repository } from '../common/entities';
-import { AppConfig } from '../config/configuration';
+import { GITHUB_OCTOKIT } from './octokit.provider';
+
+const MAINTENANCE_LABELS = ['maintenance', 'dependencies', 'chore', 'docs'];
+
+/**
+ * Shape shared by a REST `issues.listForRepo` item and an `issues` webhook
+ * payload's `issue` object — both are GitHub's Issue resource, so the same
+ * guarded upsert (see upsertIssueRecord) can accept either directly.
+ */
+export interface RawGithubIssue {
+  id: number | string;
+  number: number;
+  title: string;
+  body?: string | null;
+  state: string;
+  labels?: Array<string | { name?: string | null }>;
+  html_url: string;
+  user?: { login?: string | null } | null;
+  closed_at?: string | null;
+  updated_at: string;
+  pull_request?: unknown;
+}
+
+/**
+ * Thrown when a sync is interrupted (e.g. rate-limit retries exhausted,
+ * or a non-retryable error) partway through. Distinct from a generic Error
+ * so callers/monitoring can tell "some issues may be missing, re-run this"
+ * apart from a silent partial success — see #24. Re-running syncRepository/
+ * syncIssues is always safe: every issue already persisted is skipped or
+ * refreshed idempotently by upsertIssueRecord, so no work is duplicated and
+ * no permanent gap is left by resuming.
+ */
+export class GithubSyncInterruptedError extends Error {
+  constructor(
+    public readonly owner: string,
+    public readonly repo: string,
+    public readonly issuesSyncedBeforeFailure: number,
+    public readonly cause: Error,
+  ) {
+    super(
+      `GitHub sync for ${owner}/${repo} was interrupted after persisting ` +
+        `${issuesSyncedBeforeFailure} issue(s): ${cause.message}. ` +
+        `Already-synced issues are safe; re-run the sync to resume — ` +
+        `upserts are idempotent so no work will be duplicated.`,
+    );
+    this.name = 'GithubSyncInterruptedError';
+  }
+}
 
 /**
  * Imports repositories, issues, and PR metadata from the GitHub REST API via
  * Octokit. Uses a static GITHUB_API_TOKEN for now (personal access token or
  * GitHub App installation token).
+ *
+ * The Octokit client (injected via GITHUB_OCTOKIT, see octokit.provider.ts)
+ * is configured with retry + throttling plugins so primary/secondary rate
+ * limits and transient 5xx/network errors back off and retry automatically
+ * up to a hard ceiling, rather than throwing straight into syncIssues.
  *
  * TODO: move to a GitHub App installation-token flow (one token per
  * installation, refreshed automatically) instead of a single static token so
@@ -18,21 +69,19 @@ import { AppConfig } from '../config/configuration';
 @Injectable()
 export class GithubSyncService {
   private readonly logger = new Logger(GithubSyncService.name);
-  private readonly octokit: Octokit;
 
   constructor(
-    private readonly configService: ConfigService<AppConfig, true>,
+    @Inject(GITHUB_OCTOKIT) private readonly octokit: Octokit,
     @InjectRepository(Repository)
     private readonly repositoryRepo: TypeOrmRepository<Repository>,
     @InjectRepository(Issue)
     private readonly issueRepo: TypeOrmRepository<Issue>,
-  ) {
-    const token = this.configService.get('github', { infer: true }).apiToken;
-    this.octokit = new Octokit(token ? { auth: token } : {});
-  }
+  ) {}
 
   /** Imports (or refreshes) a single repository and all of its open+closed issues. */
   async syncRepository(owner: string, repo: string): Promise<Repository> {
+    await this.logRateLimitStatus(`before ${owner}/${repo}`);
+
     const { data: repoData } = await this.octokit.repos.get({ owner, repo });
 
     let repository = await this.repositoryRepo.findOne({
@@ -57,63 +106,122 @@ export class GithubSyncService {
       : this.repositoryRepo.create(attrs);
     repository = await this.repositoryRepo.save(repository);
 
-    await this.syncIssues(repository, owner, repo);
+    try {
+      await this.syncIssues(repository, owner, repo);
+    } finally {
+      await this.logRateLimitStatus(`after ${owner}/${repo}`);
+    }
     return repository;
   }
 
+  /**
+   * Pages through every issue for a repo, persisting each page as soon as
+   * it's fetched (rather than collecting the whole paginated result first)
+   * so a rate-limit/network failure on a later page doesn't discard the
+   * issues already fetched — those stay durably saved, and re-running the
+   * sync resumes via the idempotent upsert below rather than starting over.
+   */
   async syncIssues(
     repository: Repository,
     owner: string,
     repo: string,
   ): Promise<Issue[]> {
-    const issues = await this.octokit.paginate(
-      this.octokit.issues.listForRepo,
-      {
-        owner,
-        repo,
-        state: 'all',
-        per_page: 100,
-      },
-    );
-
     const saved: Issue[] = [];
-    for (const raw of issues) {
-      // Octokit returns PRs in the issues list too; skip those.
-      if ('pull_request' in raw && raw.pull_request) continue;
+    let pagesFetched = 0;
 
-      let issue = await this.issueRepo.findOne({
-        where: { githubIssueId: String(raw.id) },
-      });
+    try {
+      for await (const response of this.octokit.paginate.iterator(
+        this.octokit.issues.listForRepo,
+        { owner, repo, state: 'all', per_page: 100 },
+      )) {
+        pagesFetched += 1;
+        for (const raw of response.data as RawGithubIssue[]) {
+          // Octokit returns PRs in the issues list too; skip those.
+          if (raw.pull_request) continue;
 
-      const labels = (raw.labels ?? []).map((l) =>
-        typeof l === 'string' ? l : (l.name ?? ''),
+          const { issue, applied } = await this.upsertIssueRecord(
+            repository.id,
+            raw,
+          );
+          if (applied) saved.push(issue);
+        }
+      }
+    } catch (err) {
+      const cause = err as Error;
+      this.logger.error(
+        `GitHub sync interrupted for ${owner}/${repo} after ${pagesFetched} ` +
+          `page(s) / ${saved.length} issue(s) persisted: ${cause.message}`,
       );
-      const attrs = {
-        repositoryId: repository.id,
-        githubIssueId: String(raw.id),
-        number: raw.number,
-        title: raw.title,
-        body: raw.body ?? null,
-        state: raw.state as 'open' | 'closed',
-        labels,
-        githubUrl: raw.html_url,
-        authorLogin: raw.user?.login ?? null,
-        isMaintenanceType: labels.some((l) =>
-          ['maintenance', 'dependencies', 'chore', 'docs'].includes(
-            l.toLowerCase(),
-          ),
-        ),
-        closedAt: raw.closed_at ? new Date(raw.closed_at) : null,
-      };
-
-      issue = issue
-        ? this.issueRepo.merge(issue, attrs)
-        : this.issueRepo.create(attrs);
-      saved.push(await this.issueRepo.save(issue));
+      throw new GithubSyncInterruptedError(owner, repo, saved.length, cause);
     }
 
     this.logger.log(`Synced ${saved.length} issues for ${owner}/${repo}`);
     return saved;
+  }
+
+  /**
+   * Upserts a single issue, guarded by GitHub's own `updated_at`: if the
+   * locally stored issue's `githubUpdatedAt` is already newer than the
+   * incoming data, the write is skipped (`applied: false`) rather than
+   * overwriting fresher data with stale data. Called by syncIssues for every
+   * page fetched from the REST API, and by GithubWebhooksService for
+   * `issues` webhook events — both write paths go through the same guard,
+   * so whichever one has the freshest GitHub-side timestamp always wins
+   * regardless of which one happens to run, or commit, second (#24).
+   */
+  async upsertIssueRecord(
+    repositoryId: string,
+    raw: RawGithubIssue,
+  ): Promise<{ issue: Issue; applied: boolean }> {
+    const githubIssueId = String(raw.id);
+    const incomingUpdatedAt = new Date(raw.updated_at);
+
+    const existing = await this.issueRepo.findOne({
+      where: { githubIssueId },
+    });
+
+    if (
+      existing?.githubUpdatedAt &&
+      existing.githubUpdatedAt.getTime() > incomingUpdatedAt.getTime()
+    ) {
+      this.logger.warn(
+        `Skipping stale write for issue ${githubIssueId} (#${raw.number}): ` +
+          `incoming updated_at ${raw.updated_at} is older than the stored ` +
+          `${existing.githubUpdatedAt.toISOString()}`,
+      );
+      return { issue: existing, applied: false };
+    }
+
+    const labels = (raw.labels ?? []).map((l) =>
+      typeof l === 'string' ? l : (l.name ?? ''),
+    );
+    const attrs = {
+      repositoryId,
+      githubIssueId,
+      number: raw.number,
+      title: raw.title,
+      body: raw.body ?? null,
+      state: raw.state as 'open' | 'closed',
+      labels,
+      githubUrl: raw.html_url,
+      authorLogin: raw.user?.login ?? null,
+      isMaintenanceType: labels.some((l) =>
+        MAINTENANCE_LABELS.includes(l.toLowerCase()),
+      ),
+      closedAt: raw.closed_at ? new Date(raw.closed_at) : null,
+      githubUpdatedAt: incomingUpdatedAt,
+    };
+
+    const issue = existing
+      ? this.issueRepo.merge(existing, attrs)
+      : this.issueRepo.create(attrs);
+    return { issue: await this.issueRepo.save(issue), applied: true };
+  }
+
+  async findRepositoryByGithubId(
+    githubRepoId: string,
+  ): Promise<Repository | null> {
+    return this.repositoryRepo.findOne({ where: { githubRepoId } });
   }
 
   /** Fetches a single PR's merge status directly from the API (used by webhook fallback verification). */
@@ -138,5 +246,26 @@ export class GithubSyncService {
     number: number,
   ): Promise<Issue | null> {
     return this.issueRepo.findOne({ where: { repositoryId, number } });
+  }
+
+  /**
+   * Logs remaining/limit for the core REST rate-limit budget around large
+   * sync operations (#24), so a mid-sync rate-limit interruption shows up as
+   * an obviously-low "before" number in logs rather than a mystery failure.
+   * Best-effort: a failure to fetch rate-limit status never blocks the sync.
+   */
+  private async logRateLimitStatus(label: string): Promise<void> {
+    try {
+      const { data } = await this.octokit.rest.rateLimit.get();
+      const { limit, remaining, reset } = data.resources.core;
+      this.logger.log(
+        `[rate-limit ${label}] core: ${remaining}/${limit} remaining, ` +
+          `resets at ${new Date(reset * 1000).toISOString()}`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to fetch rate-limit status (${label}): ${(err as Error).message}`,
+      );
+    }
   }
 }

--- a/src/github/github-webhooks.service.spec.ts
+++ b/src/github/github-webhooks.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { GithubWebhooksService } from './github-webhooks.service';
+import { GithubSyncService } from './github-sync.service';
 import { BountiesService } from '../bounties/bounties.service';
 import { Bounty, Issue, WebhookEvent } from '../common/entities';
 import { WebhookEventStatus } from '../common/enums';
@@ -15,6 +16,10 @@ describe('GithubWebhooksService', () => {
   let bountiesService: {
     markInReview: jest.Mock;
     markMergedAndRelease: jest.Mock;
+  };
+  let syncService: {
+    findRepositoryByGithubId: jest.Mock;
+    upsertIssueRecord: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -31,6 +36,10 @@ describe('GithubWebhooksService', () => {
       markInReview: jest.fn().mockResolvedValue(undefined),
       markMergedAndRelease: jest.fn().mockResolvedValue(undefined),
     };
+    syncService = {
+      findRepositoryByGithubId: jest.fn(),
+      upsertIssueRecord: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -46,6 +55,7 @@ describe('GithubWebhooksService', () => {
         { provide: getRepositoryToken(Issue), useValue: issueRepo },
         { provide: getRepositoryToken(Bounty), useValue: bountyRepo },
         { provide: BountiesService, useValue: bountiesService },
+        { provide: GithubSyncService, useValue: syncService },
       ],
     }).compile();
 
@@ -124,5 +134,73 @@ describe('GithubWebhooksService', () => {
     };
     await service.handleEvent('pull_request', 'delivery-3', payload, true);
     expect(bountiesService.markMergedAndRelease).not.toHaveBeenCalled();
+  });
+
+  describe('"issues" webhook events (#24)', () => {
+    const payload = {
+      action: 'edited',
+      issue: {
+        id: 555,
+        number: 12,
+        title: 'Updated title',
+        state: 'open',
+        html_url: 'https://github.com/acme/widgets/issues/12',
+        updated_at: '2026-01-10T00:00:00Z',
+      },
+      repository: { id: 42, full_name: 'acme/widgets' },
+    };
+
+    it('delegates to the same guarded upsert sync uses, for a tracked repository', async () => {
+      syncService.findRepositoryByGithubId.mockResolvedValue({ id: 'repo-1' });
+      syncService.upsertIssueRecord.mockResolvedValue({
+        issue: { id: 'issue-1' },
+        applied: true,
+      });
+
+      const event = await service.handleEvent(
+        'issues',
+        'delivery-4',
+        payload,
+        true,
+      );
+
+      expect(syncService.findRepositoryByGithubId).toHaveBeenCalledWith('42');
+      expect(syncService.upsertIssueRecord).toHaveBeenCalledWith(
+        'repo-1',
+        payload.issue,
+      );
+      expect(event.status).toBe(WebhookEventStatus.PROCESSED);
+    });
+
+    it('ignores events for a repository this app is not tracking, without erroring', async () => {
+      syncService.findRepositoryByGithubId.mockResolvedValue(null);
+
+      const event = await service.handleEvent(
+        'issues',
+        'delivery-5',
+        payload,
+        true,
+      );
+
+      expect(syncService.upsertIssueRecord).not.toHaveBeenCalled();
+      expect(event.status).toBe(WebhookEventStatus.PROCESSED);
+    });
+
+    it('still marks the event processed when the upsert is rejected as stale', async () => {
+      syncService.findRepositoryByGithubId.mockResolvedValue({ id: 'repo-1' });
+      syncService.upsertIssueRecord.mockResolvedValue({
+        issue: { id: 'issue-1' },
+        applied: false,
+      });
+
+      const event = await service.handleEvent(
+        'issues',
+        'delivery-6',
+        payload,
+        true,
+      );
+
+      expect(event.status).toBe(WebhookEventStatus.PROCESSED);
+    });
   });
 });

--- a/src/github/github-webhooks.service.ts
+++ b/src/github/github-webhooks.service.ts
@@ -7,6 +7,7 @@ import { BountyStatus, WebhookEventStatus } from '../common/enums';
 import { AppConfig } from '../config/configuration';
 import { verifyGithubSignature } from './webhook-signature.util';
 import { BountiesService } from '../bounties/bounties.service';
+import { GithubSyncService, RawGithubIssue } from './github-sync.service';
 
 interface GithubPullRequestPayload {
   action: string;
@@ -18,6 +19,12 @@ interface GithubPullRequestPayload {
     body?: string | null;
     title?: string;
   };
+  repository: { id: number; full_name: string };
+}
+
+interface GithubIssuesEventPayload {
+  action: string;
+  issue: RawGithubIssue;
   repository: { id: number; full_name: string };
 }
 
@@ -36,6 +43,7 @@ export class GithubWebhooksService {
     @InjectRepository(Issue) private readonly issueRepo: Repository<Issue>,
     @InjectRepository(Bounty) private readonly bountyRepo: Repository<Bounty>,
     private readonly bountiesService: BountiesService,
+    private readonly syncService: GithubSyncService,
   ) {}
 
   verifySignature(
@@ -77,6 +85,10 @@ export class GithubWebhooksService {
       if (eventType === 'pull_request') {
         await this.handlePullRequest(
           payload as unknown as GithubPullRequestPayload,
+        );
+      } else if (eventType === 'issues') {
+        await this.handleIssueEvent(
+          payload as unknown as GithubIssuesEventPayload,
         );
       }
       event.status = WebhookEventStatus.PROCESSED;
@@ -133,6 +145,38 @@ export class GithubWebhooksService {
         );
       }
       await this.bountiesService.markMergedAndRelease(bounty.id);
+    }
+  }
+
+  /**
+   * Keeps a tracked issue's title/body/state/labels in sync with an
+   * `issues` webhook event (opened/edited/closed/reopened/...), through the
+   * same optimistic-concurrency-guarded upsert a full sync uses — see
+   * GithubSyncService.upsertIssueRecord's doc comment for why this is the
+   * one write path both sync and webhooks share (#24).
+   */
+  private async handleIssueEvent(
+    payload: GithubIssuesEventPayload,
+  ): Promise<void> {
+    const repository = await this.syncService.findRepositoryByGithubId(
+      String(payload.repository.id),
+    );
+    if (!repository) {
+      this.logger.warn(
+        `Ignoring "issues" webhook for untracked repository ${payload.repository.full_name}`,
+      );
+      return;
+    }
+
+    const { applied } = await this.syncService.upsertIssueRecord(
+      repository.id,
+      payload.issue,
+    );
+    if (!applied) {
+      this.logger.log(
+        `Webhook "issues" update for #${payload.issue.number} in ` +
+          `${payload.repository.full_name} was stale relative to stored data; ignored`,
+      );
     }
   }
 

--- a/src/github/github.module.ts
+++ b/src/github/github.module.ts
@@ -6,6 +6,7 @@ import { GithubController } from './github.controller';
 import { GithubWebhooksService } from './github-webhooks.service';
 import { GithubWebhooksController } from './github-webhooks.controller';
 import { BountiesModule } from '../bounties/bounties.module';
+import { githubOctokitProvider } from './octokit.provider';
 
 @Module({
   imports: [
@@ -13,7 +14,7 @@ import { BountiesModule } from '../bounties/bounties.module';
     BountiesModule,
   ],
   controllers: [GithubController, GithubWebhooksController],
-  providers: [GithubSyncService, GithubWebhooksService],
+  providers: [githubOctokitProvider, GithubSyncService, GithubWebhooksService],
   exports: [GithubSyncService],
 })
 export class GithubModule {}

--- a/src/github/octokit.provider.spec.ts
+++ b/src/github/octokit.provider.spec.ts
@@ -1,0 +1,69 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AppConfig } from '../config/configuration';
+import {
+  GITHUB_MAX_RETRIES,
+  createGithubOctokit,
+  makeLimitHandler,
+} from './octokit.provider';
+
+function mockConfigService(apiToken: string): ConfigService<AppConfig, true> {
+  return {
+    get: () => ({ apiToken }),
+  } as unknown as ConfigService<AppConfig, true>;
+}
+
+describe('makeLimitHandler', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  const options = {
+    method: 'GET',
+    url: 'https://api.github.com/repos/a/b/issues',
+  };
+
+  it.each(['primary', 'secondary'] as const)(
+    'retries while under the ceiling for a %s rate limit',
+    (kind) => {
+      const handler = makeLimitHandler(kind);
+      const result = handler(5, options, {}, 0);
+      expect(result).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(kind));
+    },
+  );
+
+  it('stops retrying once GITHUB_MAX_RETRIES is reached, so a persistent outage cannot retry forever', () => {
+    const handler = makeLimitHandler('primary');
+    const result = handler(5, options, {}, GITHUB_MAX_RETRIES);
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('giving up'));
+  });
+
+  it('logs the method/url/retryAfter so the interruption is traceable', () => {
+    const handler = makeLimitHandler('secondary');
+    handler(12, options, {}, 1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('GET https://api.github.com/repos/a/b/issues'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('12s'));
+  });
+});
+
+describe('createGithubOctokit', () => {
+  it('constructs an authenticated Octokit instance when a token is configured', () => {
+    const octokit = createGithubOctokit(mockConfigService('test-token'));
+    expect(octokit).toBeDefined();
+    expect(typeof octokit.request).toBe('function');
+  });
+
+  it('constructs an unauthenticated Octokit instance when no token is configured', () => {
+    expect(() => createGithubOctokit(mockConfigService(''))).not.toThrow();
+  });
+});

--- a/src/github/octokit.provider.ts
+++ b/src/github/octokit.provider.ts
@@ -1,0 +1,74 @@
+import { Logger, Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Octokit } from '@octokit/rest';
+import { retry } from '@octokit/plugin-retry';
+import { throttling } from '@octokit/plugin-throttling';
+import { AppConfig } from '../config/configuration';
+
+export const GITHUB_OCTOKIT = Symbol('GITHUB_OCTOKIT');
+
+/**
+ * Hard ceiling on retries for both plugins below, applied consistently so a
+ * persistent outage or a misconfigured token can't retry forever — see #24.
+ * GitHub's primary limit resets hourly and secondary limits are usually
+ * seconds-to-low-minutes, so 3 attempts (4 total requests) is enough to ride
+ * out a transient spike without a sync hanging indefinitely.
+ */
+export const GITHUB_MAX_RETRIES = 3;
+
+const RetryingOctokit = Octokit.plugin(retry, throttling);
+
+const octokitLogger = new Logger('GithubOctokit');
+
+/**
+ * Logs and caps retries for a primary (5000 req/hr) or secondary
+ * (abuse-detection) rate-limit hit. Returning true tells the throttling
+ * plugin to retry after `retryAfter` seconds; false lets the original
+ * error propagate to the caller (syncIssues wraps that in a clearly
+ * reported, resumable error — see GithubSyncInterruptedError).
+ */
+export function makeLimitHandler(kind: 'primary' | 'secondary') {
+  return (
+    retryAfter: number,
+    options: { method: string; url: string },
+    _octokit: unknown,
+    retryCount: number,
+  ): boolean => {
+    const willRetry = retryCount < GITHUB_MAX_RETRIES;
+    octokitLogger.warn(
+      `GitHub ${kind} rate limit hit for ${options.method} ${options.url} — ` +
+        `retrying after ${retryAfter}s (attempt ${retryCount + 1}/${GITHUB_MAX_RETRIES + 1})` +
+        (willRetry ? '' : ' — giving up, ceiling reached'),
+    );
+    return willRetry;
+  };
+}
+
+export function createGithubOctokit(
+  configService: ConfigService<AppConfig, true>,
+): Octokit {
+  const token = configService.get('github', { infer: true }).apiToken;
+
+  return new RetryingOctokit({
+    ...(token ? { auth: token } : {}),
+    retry: {
+      retries: GITHUB_MAX_RETRIES,
+      // plugin-retry's default doNotRetry already excludes 403 (secondary
+      // rate limits); 429 (primary rate limit) is added here so it's retried
+      // exactly once, by plugin-throttling's onRateLimit below, which knows
+      // the actual Retry-After/x-ratelimit-reset values — plugin-retry's own
+      // generic backoff would otherwise race it on the same error.
+      doNotRetry: [400, 401, 403, 404, 410, 422, 429, 451],
+    },
+    throttle: {
+      onRateLimit: makeLimitHandler('primary'),
+      onSecondaryRateLimit: makeLimitHandler('secondary'),
+    },
+  });
+}
+
+export const githubOctokitProvider: Provider = {
+  provide: GITHUB_OCTOKIT,
+  useFactory: createGithubOctokit,
+  inject: [ConfigService],
+};


### PR DESCRIPTION
## Summary

Closes #24.

`GithubSyncService` built a plain Octokit client with no retry/backoff
and paginated via `octokit.paginate()`, which buffers every page
before returning. Investigated the concrete failure modes the issue
asked about:

- **A 429/403 mid-pagination throws with zero issues saved for that
  call** (not "half-synced" — `paginate()` never returns anything until
  every page succeeds, so a failure on page N discards pages 1..N-1
  too), and propagates as an unhandled, opaque Octokit error.
- **No optimistic-concurrency guard** on the issue upsert — and, on
  inspection, no webhook path even *wrote* to `Issue`'s own fields at
  all yet (only read it, to find a linked bounty), so the "sync clobbers
  a webhook update" race had no real webhook-side write to guard against.

### Changes

- **Retry/throttle plugins** (`octokit.provider.ts`, new): Octokit
  configured with `@octokit/plugin-retry` + `@octokit/plugin-throttling`
  behind a `GITHUB_OCTOKIT` DI token. `retry.doNotRetry` explicitly adds
  429 on top of the plugin's default list so it doesn't race
  `throttling`'s own retry-after-aware handling of the same error.
  `onRateLimit`/`onSecondaryRateLimit` share one handler that logs the
  hit and enforces a hard ceiling (`GITHUB_MAX_RETRIES = 3`) so a
  persistent outage can't retry forever.
- **Resumable sync**: `syncIssues` switched from `octokit.paginate()` to
  `octokit.paginate.iterator()`, persisting each page as it's fetched.
  A failure now surfaces as `GithubSyncInterruptedError` (owner, repo,
  `issuesSyncedBeforeFailure`, cause) instead of an opaque error —
  "resumable failure with a clear signal," never a silent partial sync.
  Re-running is always safe: every write goes through the idempotent,
  guarded upsert below.
- **Webhook-vs-sync race guard**: added `Issue.githubUpdatedAt`
  (migration included) and `GithubSyncService.upsertIssueRecord`, which
  skips a write if the stored `githubUpdatedAt` is already newer than
  the incoming data. Added a real `issues` webhook event handler
  (opened/edited/closed/reopened/...) that calls the *same* guarded
  upsert sync uses — this is what makes the ordering-independence
  guarantee real, rather than guarding a write path that didn't exist.
- **Rate-limit budget logging**: `syncRepository` logs the core
  rate-limit budget before and after via `octokit.rest.rateLimit.get()`,
  best-effort (a failed lookup never blocks the sync).
- **Test infra fix**: `@octokit/rest`/`plugin-retry`/`plugin-throttling`
  are ESM-only with no CJS build. Modern Node (20.19+/22.12+, incl. CI's
  Node 24) `require()`s them fine natively, but Jest's default config
  only transforms non-`node_modules` code, so anything importing the
  sync service failed to parse under `ts-jest`. Widened
  `transformIgnorePatterns` to cover `@octokit/*` and its ESM-only
  deps — test-tooling only, confirmed no production runtime impact by
  requiring the actual compiled `dist/` output directly under Node.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds; manually verified the compiled
      `dist/github/*.js` load correctly under real Node (confirms the
      Jest transform fix is test-tooling-only, not masking a runtime issue)
- [x] `npm test` — 114/121 passing; the 7 failures are all in
      `escrow-fk-integrity.integration.spec.ts`, a pre-existing test
      requiring a live Postgres connection I don't have locally (CI
      provides one via `services.postgres`) — confirmed pre-existing
      and unrelated by reproducing the identical failure on `main` before
      any of my changes
- [x] New coverage: simulated 429 mid-pagination (partial progress
      persisted, `GithubSyncInterruptedError` thrown with accurate
      counts), ordering-independence for the concurrency guard in both
      directions, rate-limit logging before/after sync, and the retry/
      throttle handlers' ceiling behavior