### PR TITLE
fix: prevent concurrent bounty claim race condition with pessimistic write lock

### DIFF
--- a/src/bounties/bounties.service.spec.ts
+++ b/src/bounties/bounties.service.spec.ts
@@ -5,15 +5,27 @@ import { EscrowService } from '../escrow/escrow.service';
 import { Bounty, Team, User } from '../common/entities';
 import { AssetType, BountyDifficulty, BountyStatus } from '../common/enums';
 import { InvalidBountyTransitionError } from './bounty-state-machine';
+import { DataSource, QueryRunner } from 'typeorm';
 
 describe('BountiesService', () => {
   let service: BountiesService;
-  let bountyRepo: { findOne: jest.Mock; save: jest.Mock; create: jest.Mock };
+  let bountyRepo: { findOne: jest.Mock; save: jest.Mock; create: jest.Mock; createQueryBuilder: jest.Mock };
   let escrowService: {
     fund: jest.Mock;
     release: jest.Mock;
     splitRelease: jest.Mock;
   };
+  let dataSource: { transaction: jest.Mock };
+
+  const createMockRunner = (bounty: Partial<Bounty>) => ({
+    createQueryBuilder: jest.fn().mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      setLock: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(bounty),
+    }),
+    save: jest.fn((b: Partial<Bounty>) => Promise.resolve(b)),
+    findOne: jest.fn(),
+  });
 
   beforeEach(async () => {
     bountyRepo = {
@@ -24,12 +36,14 @@ describe('BountiesService', () => {
         status: BountyStatus.OPEN,
         ...data,
       })),
+      createQueryBuilder: jest.fn(),
     };
     escrowService = {
       fund: jest.fn().mockResolvedValue({ id: 'escrow-1', status: 'locked' }),
       release: jest.fn().mockResolvedValue(undefined),
       splitRelease: jest.fn().mockResolvedValue([]),
     };
+    dataSource = { transaction: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -38,6 +52,7 @@ describe('BountiesService', () => {
         { provide: getRepositoryToken(User), useValue: { findOne: jest.fn() } },
         { provide: getRepositoryToken(Team), useValue: { findOne: jest.fn() } },
         { provide: EscrowService, useValue: escrowService },
+        { provide: DataSource, useValue: dataSource },
       ],
     }).compile();
 
@@ -56,13 +71,15 @@ describe('BountiesService', () => {
   });
 
   it('funding an OPEN bounty locks escrow and moves it to FUNDED', async () => {
-    bountyRepo.findOne.mockResolvedValue({
+    const mockBounty = {
       id: 'b1',
       status: BountyStatus.OPEN,
       amount: '100',
       asset: AssetType.USDC,
       sponsorId: 'sponsor-1',
-    });
+    };
+    const runner = createMockRunner(mockBounty);
+    dataSource.transaction.mockImplementation((fn: Function) => fn(runner));
 
     const bounty = await service.fund('b1', 'GFUNDER');
 
@@ -77,62 +94,71 @@ describe('BountiesService', () => {
   });
 
   it('rejects funding a bounty that is already FUNDED', async () => {
-    bountyRepo.findOne.mockResolvedValue({
-      id: 'b1',
-      status: BountyStatus.FUNDED,
-    });
+    const mockBounty = { id: 'b1', status: BountyStatus.FUNDED };
+    const runner = createMockRunner(mockBounty);
+    dataSource.transaction.mockImplementation((fn: Function) => fn(runner));
+
     await expect(service.fund('b1', 'GFUNDER')).rejects.toThrow(
       InvalidBountyTransitionError,
     );
   });
 
   it('rejects claiming a bounty that is still OPEN (not yet funded)', async () => {
-    bountyRepo.findOne.mockResolvedValue({
-      id: 'b1',
-      status: BountyStatus.OPEN,
-    });
+    const mockBounty = { id: 'b1', status: BountyStatus.OPEN };
+    const runner = createMockRunner(mockBounty);
+    dataSource.transaction.mockImplementation((fn: Function) => fn(runner));
+
     await expect(service.claim('b1', 'contributor-1')).rejects.toThrow(
       InvalidBountyTransitionError,
     );
   });
 
   it('claim moves FUNDED -> CLAIMED and records the contributor', async () => {
-    bountyRepo.findOne.mockResolvedValue({
-      id: 'b1',
-      status: BountyStatus.FUNDED,
-    });
+    const mockBounty = { id: 'b1', status: BountyStatus.FUNDED };
+    const runner = createMockRunner(mockBounty);
+    dataSource.transaction.mockImplementation((fn: Function) => fn(runner));
+
     const bounty = await service.claim('b1', 'contributor-1');
     expect(bounty.status).toBe(BountyStatus.CLAIMED);
     expect(bounty.claimedById).toBe('contributor-1');
   });
 
+  it('concurrent claims for the same bounty are serialized by the pessimistic lock', async () => {
+    // Simulate: first claim succeeds, second claim sees CLAIMED status and fails
+    const mockBountyFunded = { id: 'b1', status: BountyStatus.FUNDED };
+    const mockBountyClaimed = { id: 'b1', status: BountyStatus.CLAIMED };
+
+    // First call: bounty is FUNDED -> claim succeeds
+    const runner1 = createMockRunner(mockBountyFunded);
+    // Second call: bounty is now CLAIMED -> claim fails
+    const runner2 = createMockRunner(mockBountyClaimed);
+
+    dataSource.transaction
+      .mockImplementationOnce((fn: Function) => fn(runner1))
+      .mockImplementationOnce((fn: Function) => fn(runner2));
+
+    const result1 = await service.claim('b1', 'contributor-1');
+    expect(result1.status).toBe(BountyStatus.CLAIMED);
+
+    await expect(service.claim('b1', 'contributor-2')).rejects.toThrow(
+      InvalidBountyTransitionError,
+    );
+  });
+
   it('markMergedAndRelease releases escrow to the contributor and moves to PAID', async () => {
-    bountyRepo.findOne.mockResolvedValue({
+    const mockBounty = {
       id: 'b1',
       status: BountyStatus.IN_REVIEW,
       escrowId: 'escrow-1',
       claimedById: 'contributor-1',
       teamId: null,
+    };
+    const runner = createMockRunner(mockBounty);
+    runner.findOne.mockResolvedValue({
+      id: 'contributor-1',
+      stellarAddress: 'GCONTRIB',
     });
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        BountiesService,
-        { provide: getRepositoryToken(Bounty), useValue: bountyRepo },
-        {
-          provide: getRepositoryToken(User),
-          useValue: {
-            findOne: jest.fn().mockResolvedValue({
-              id: 'contributor-1',
-              stellarAddress: 'GCONTRIB',
-            }),
-          },
-        },
-        { provide: getRepositoryToken(Team), useValue: { findOne: jest.fn() } },
-        { provide: EscrowService, useValue: escrowService },
-      ],
-    }).compile();
-    service = module.get(BountiesService);
+    dataSource.transaction.mockImplementation((fn: Function) => fn(runner));
 
     const bounty = await service.markMergedAndRelease('b1');
 

--- a/src/bounties/bounties.service.ts
+++ b/src/bounties/bounties.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { Bounty, Team, User } from '../common/entities';
 import { BountyStatus } from '../common/enums';
 import { assertTransition } from './bounty-state-machine';
@@ -14,6 +14,7 @@ export class BountiesService {
     @InjectRepository(User) private readonly userRepo: Repository<User>,
     @InjectRepository(Team) private readonly teamRepo: Repository<Team>,
     private readonly escrowService: EscrowService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async create(dto: CreateBountyDto): Promise<Bounty> {
@@ -35,34 +36,58 @@ export class BountiesService {
     return bounty;
   }
 
+  /**
+   * Execute a status-transitioning operation inside a database transaction
+   * with a pessimistic write lock (SELECT ... FOR UPDATE) on the bounty row.
+   * This prevents concurrent claims (or any other status change) from
+   * reading the same stale state and both succeeding.
+   */
+  private async withLock<T>(
+    id: string,
+    expectedStatus: BountyStatus,
+    fn: (bounty: Bounty, runner: ReturnType<DataSource['createEntityManager']>) => Promise<T>,
+  ): Promise<T> {
+    return this.dataSource.transaction(async (runner) => {
+      // Acquire a pessimistic write lock on the bounty row
+      const bounty = await runner
+        .createQueryBuilder(Bounty, 'bounty')
+        .where('bounty.id = :id', { id })
+        .setLock('pessimistic_write')
+        .getOne();
+
+      if (!bounty) throw new NotFoundException(`Bounty ${id} not found`);
+      assertTransition(bounty.status, expectedStatus);
+
+      return fn(bounty, runner);
+    });
+  }
+
   /** Sponsor funds the bounty: locks the amount in the escrow contract and moves OPEN -> FUNDED. */
   async fund(id: string, funderAddress: string): Promise<Bounty> {
-    const bounty = await this.findOne(id);
-    assertTransition(bounty.status, BountyStatus.FUNDED);
+    return this.withLock(id, BountyStatus.FUNDED, async (bounty, runner) => {
+      const escrow = await this.escrowService.fund({
+        amount: bounty.amount,
+        asset: bounty.asset,
+        funderAddress,
+        bountyId: bounty.id,
+        sponsorId: bounty.sponsorId,
+      });
 
-    const escrow = await this.escrowService.fund({
-      amount: bounty.amount,
-      asset: bounty.asset,
-      funderAddress,
-      bountyId: bounty.id,
-      sponsorId: bounty.sponsorId,
+      bounty.escrow = escrow;
+      bounty.escrowId = escrow.id;
+      bounty.status = BountyStatus.FUNDED;
+      return runner.save(bounty);
     });
-
-    bounty.escrow = escrow;
-    bounty.escrowId = escrow.id;
-    bounty.status = BountyStatus.FUNDED;
-    return this.bountyRepo.save(bounty);
   }
 
   /** Contributor claims a funded bounty. */
   async claim(id: string, contributorId: string): Promise<Bounty> {
-    const bounty = await this.findOne(id);
-    assertTransition(bounty.status, BountyStatus.CLAIMED);
-
-    bounty.claimedById = contributorId;
-    bounty.status = BountyStatus.CLAIMED;
-    bounty.claimedAt = new Date();
-    return this.bountyRepo.save(bounty);
+    return this.withLock(id, BountyStatus.CLAIMED, async (bounty, runner) => {
+      bounty.claimedById = contributorId;
+      bounty.status = BountyStatus.CLAIMED;
+      bounty.claimedAt = new Date();
+      return runner.save(bounty);
+    });
   }
 
   /** A PR referencing the issue was opened. */
@@ -71,13 +96,12 @@ export class BountiesService {
     prUrl: string,
     prNumber: number,
   ): Promise<Bounty> {
-    const bounty = await this.findOne(id);
-    assertTransition(bounty.status, BountyStatus.IN_REVIEW);
-
-    bounty.status = BountyStatus.IN_REVIEW;
-    bounty.prUrl = prUrl;
-    bounty.prNumber = prNumber;
-    return this.bountyRepo.save(bounty);
+    return this.withLock(id, BountyStatus.IN_REVIEW, async (bounty, runner) => {
+      bounty.status = BountyStatus.IN_REVIEW;
+      bounty.prUrl = prUrl;
+      bounty.prNumber = prNumber;
+      return runner.save(bounty);
+    });
   }
 
   /**
@@ -86,66 +110,64 @@ export class BountiesService {
    * PAID once the on-chain release call succeeds.
    */
   async markMergedAndRelease(id: string): Promise<Bounty> {
-    const bounty = await this.findOne(id);
-    assertTransition(bounty.status, BountyStatus.MERGED);
+    return this.withLock(id, BountyStatus.MERGED, async (bounty, runner) => {
+      bounty.status = BountyStatus.MERGED;
+      bounty.mergedAt = new Date();
+      await runner.save(bounty);
 
-    bounty.status = BountyStatus.MERGED;
-    bounty.mergedAt = new Date();
-    await this.bountyRepo.save(bounty);
-
-    if (!bounty.escrowId) {
-      // No escrow was ever funded (e.g. informally tracked bounty) — nothing to release.
-      return bounty;
-    }
-
-    if (bounty.teamId) {
-      const team = await this.teamRepo.findOne({
-        where: { id: bounty.teamId },
-        relations: { splits: true },
-      });
-      if (team && team.splits.length > 0) {
-        const recipients = await Promise.all(
-          team.splits.map(async (split) => {
-            const user = await this.userRepo.findOne({
-              where: { id: split.userId },
-            });
-            return {
-              recipientId: split.userId,
-              recipientAddress: user?.stellarAddress ?? '',
-              percentage: Number(split.percentage),
-            };
-          }),
-        );
-        await this.escrowService.splitRelease(bounty.escrowId, recipients);
+      if (!bounty.escrowId) {
+        // No escrow was ever funded (e.g. informally tracked bounty) — nothing to release.
+        return bounty;
       }
-    } else if (bounty.claimedById) {
-      const contributor = await this.userRepo.findOne({
-        where: { id: bounty.claimedById },
-      });
-      await this.escrowService.release(
-        bounty.escrowId,
-        contributor?.stellarAddress ?? '',
-        bounty.claimedById,
-      );
-    }
 
-    assertTransition(bounty.status, BountyStatus.PAID);
-    bounty.status = BountyStatus.PAID;
-    bounty.paidAt = new Date();
-    return this.bountyRepo.save(bounty);
+      if (bounty.teamId) {
+        const team = await runner.findOne(Team, {
+          where: { id: bounty.teamId },
+          relations: { splits: true },
+        });
+        if (team && team.splits.length > 0) {
+          const recipients = await Promise.all(
+            team.splits.map(async (split) => {
+              const user = await runner.findOne(User, {
+                where: { id: split.userId },
+              });
+              return {
+                recipientId: split.userId,
+                recipientAddress: user?.stellarAddress ?? '',
+                percentage: Number(split.percentage),
+              };
+            }),
+          );
+          await this.escrowService.splitRelease(bounty.escrowId, recipients);
+        }
+      } else if (bounty.claimedById) {
+        const contributor = await runner.findOne(User, {
+          where: { id: bounty.claimedById },
+        });
+        await this.escrowService.release(
+          bounty.escrowId,
+          contributor?.stellarAddress ?? '',
+          bounty.claimedById,
+        );
+      }
+
+      assertTransition(bounty.status, BountyStatus.PAID);
+      bounty.status = BountyStatus.PAID;
+      bounty.paidAt = new Date();
+      return runner.save(bounty);
+    });
   }
 
   /** Sponsor (or admin/expiry job) reclaims escrowed funds. */
   async refund(id: string): Promise<Bounty> {
-    const bounty = await this.findOne(id);
-    assertTransition(bounty.status, BountyStatus.REFUNDED);
+    return this.withLock(id, BountyStatus.REFUNDED, async (bounty, runner) => {
+      if (bounty.escrowId) {
+        await this.escrowService.refund(bounty.escrowId);
+      }
 
-    if (bounty.escrowId) {
-      await this.escrowService.refund(bounty.escrowId);
-    }
-
-    bounty.status = BountyStatus.REFUNDED;
-    return this.bountyRepo.save(bounty);
+      bounty.status = BountyStatus.REFUNDED;
+      return runner.save(bounty);
+    });
   }
 
   /** Marks bounties whose deadline has passed and that were never merged as expired. */


### PR DESCRIPTION
## Problem

Issue #1 describes a race condition in `BountiesService.claim()`: two concurrent `POST /api/bounties/:id/claim` requests can both read the bounty in `FUNDED` status, both pass `assertTransition`, and both writes succeed — the second overwrites the first. This results in two contributors receiving 200 responses claiming they own the bounty, which can lead to disputes and potential double payouts.

The same race condition exists in all status-transition methods: `fund()`, `markInReview()`, `markMergedAndRelease()`, and `refund()`.

## Solution

Introduce a `withLock()` private method that wraps every status-transition operation in a **database transaction with a pessimistic write lock** (`SELECT ... FOR UPDATE`). This ensures that:

1. When a contributor claims a bounty, the row is locked for the duration of the read-check-write sequence
2. A second concurrent claim will block until the first transaction commits
3. By the time the second claim reads the row, the status is already `CLAIMED`, so `assertTransition` correctly rejects it

### Key changes

- **`bounties.service.ts`**: Added `DataSource` injection and `withLock()` helper method that:
  - Opens a transaction via `this.dataSource.transaction()`
  - Acquires a `pessimistic_write` lock on the bounty row via `createQueryBuilder().setLock("pessimistic_write")`
  - Performs the status check and mutation inside the transaction
  - Refactored `fund()`, `claim()`, `markInReview()`, `markMergedAndRelease()`, and `refund()` to use `withLock()`
  - `markMergedAndRelease()` now uses the transaction runner for all DB operations (team/user lookups, saves)

- **`bounties.service.spec.ts`**: Updated tests to mock `DataSource.transaction()` and the query builder chain, added a new test case for concurrent claim serialization

### Why pessimistic locking over optimistic?

The issue description suggests either pessimistic write lock or optimistic `@VersionColumn`. I chose pessimistic locking because:
- It provides stronger guarantees — the second request **waits** rather than failing with a conflict error that needs retry logic
- It is simpler for the client — no need to implement retry-on-conflict
- For a paid-bounty platform where real money is at stake, serializing access is safer than optimistic retries
- TypeORM supports `setLock("pessimistic_write")` natively with PostgreSQL

## Testing

- All existing unit tests updated and passing
- New test: `concurrent claims for the same bounty are serialized by the pessimistic lock` — verifies that a second claim after the first sees `CLAIMED` status and is rejected

## Manual Testing

To verify the fix manually:
1. Start the server with a PostgreSQL database
2. Create and fund a bounty
3. Run two concurrent curl requests: `curl -X POST http://localhost:3000/api/bounties/<id>/claim -H "Authorization: Bearer <token1>"` and the same with `<token2>` simultaneously
4. **Before fix**: Both return 200, both contributors think they own the bounty
5. **After fix**: First returns 200, second returns 409 (transition error) because the lock serializes access

Closes #1