### PR TITLE
fix(users): authorize stellar-address updates by caller ID (#39)

### DIFF
--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,0 +1,74 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthenticatedRequest, UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { User } from '../common/entities';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  const mockUsersService = {
+    list: jest.fn(),
+    findById: jest.fn(),
+    setStellarAddress: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+    jest.clearAllMocks();
+  });
+
+  describe('setStellarAddress', () => {
+    it('allows a user to update their own stellar address', async () => {
+      const userId = 'user-123';
+      const dto = {
+        stellarAddress:
+          'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+      };
+      const req = {
+        user: { userId: 'user-123', username: 'alice' },
+      } as unknown as AuthenticatedRequest;
+      const updatedUser = {
+        id: userId,
+        stellarAddress: dto.stellarAddress,
+      } as User;
+
+      mockUsersService.setStellarAddress.mockResolvedValue(updatedUser);
+
+      const result = await controller.setStellarAddress(userId, dto, req);
+
+      expect(mockUsersService.setStellarAddress).toHaveBeenCalledWith(
+        userId,
+        dto.stellarAddress,
+      );
+      expect(result).toEqual(updatedUser);
+    });
+
+    it('rejects update when authenticated user does not match the target id (403 Forbidden)', () => {
+      const targetUserId = 'user-target-456';
+      const dto = {
+        stellarAddress:
+          'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+      };
+      const req = {
+        user: { userId: 'user-attacker-123', username: 'eve' },
+      } as unknown as AuthenticatedRequest;
+
+      expect(() =>
+        controller.setStellarAddress(targetUserId, dto, req),
+      ).toThrow(ForbiddenException);
+
+      expect(mockUsersService.setStellarAddress).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,8 +1,27 @@
-import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Param,
+  Patch,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 import { IsString } from 'class-validator';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+export interface AuthenticatedUser {
+  userId: string;
+  username: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthenticatedUser;
+}
 
 class SetStellarAddressDto {
   @IsString()
@@ -30,7 +49,13 @@ export class UsersController {
   setStellarAddress(
     @Param('id') id: string,
     @Body() dto: SetStellarAddressDto,
+    @Req() req: AuthenticatedRequest,
   ) {
+    if (req.user?.userId !== id) {
+      throw new ForbiddenException(
+        'You are not authorized to update another user stellar address',
+      );
+    }
     return this.usersService.setStellarAddress(id, dto.stellarAddress);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #39.

### Problem
`PATCH /users/:id/stellar-address` had `JwtAuthGuard` applied but lacked authorization validation. Any authenticated user could supply another user's `:id` in the URL param and overwrite their `stellarAddress`, creating an IDOR vulnerability where bounty payouts could be redirected to an attacker's wallet.

### Changes
1. Defined `AuthenticatedRequest` interface typing `req.user` (`{ userId, username }`).
2. In `UsersController.setStellarAddress`, injected `@Req() req: AuthenticatedRequest` and added an authorization guard verifying `req.user?.userId === id`. If mismatch, throws `403 ForbiddenException`.
3. Added unit tests in `src/users/users.controller.spec.ts` covering:
   - Valid update when caller's `userId` matches the `:id` param.
   - 403 rejection when caller's `userId` differs from the target `:id` param.

### Validation
- `npm run test` passes unit tests.
- `npm run lint` and Prettier format pass cleanly.
- `npm run build` succeeds with zero errors.
