### PR TITLE
fix(teams): change TeamMemberSplit.user onDelete from CASCADE to RESTRICT (#58)

### DIFF
--- a/src/common/entities/team-member-split.entity.ts
+++ b/src/common/entities/team-member-split.entity.ts
@@ -21,7 +21,10 @@ export class TeamMemberSplit {
   @Column()
   teamId: string;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  // RESTRICT, not CASCADE: a TeamMemberSplit is a financial commitment (a promised
+  // percentage of a bounty payout). Deleting a User row must never silently delete
+  // their TeamMemberSplit row and desync the team's split percentage sum from 100%. See #58.
+  @ManyToOne(() => User, { onDelete: 'RESTRICT' })
   @JoinColumn()
   user: User;
 

--- a/src/database/migrations/1784500000000-TeamMemberSplitFkRestrict.ts
+++ b/src/database/migrations/1784500000000-TeamMemberSplitFkRestrict.ts
@@ -1,0 +1,76 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Fixes the data integrity issue described in #58:
+ * Re-points `team_member_splits.userId` foreign key from `ON DELETE CASCADE`
+ * to `ON DELETE RESTRICT`.
+ *
+ * A TeamMemberSplit represents a promised percentage of a bounty payout.
+ * Cascading user deletes silently removes individual member splits, causing
+ * the remaining split percentages to no longer sum to 100%. When such a bounty
+ * is merged and released, `EscrowService.splitRelease` / `assertValidSplits`
+ * throws a BadRequestException, permanently locking the funds and stranding
+ * the bounty in MERGED state.
+ */
+export class TeamMemberSplitFkRestrict1784500000000 implements MigrationInterface {
+  name = 'TeamMemberSplitFkRestrict1784500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.replaceForeignKeyOnDelete(
+      queryRunner,
+      'team_member_splits',
+      'userId',
+      'users',
+      'RESTRICT',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.replaceForeignKeyOnDelete(
+      queryRunner,
+      'team_member_splits',
+      'userId',
+      'users',
+      'CASCADE',
+    );
+  }
+
+  /**
+   * Finds the existing single-column foreign key from `table.column` and
+   * replaces its ON DELETE action in place, preserving whatever name
+   * `synchronize` (or a previous migration) originally gave it.
+   */
+  private async replaceForeignKeyOnDelete(
+    queryRunner: QueryRunner,
+    table: string,
+    column: string,
+    refTable: string,
+    onDelete: 'SET NULL' | 'CASCADE' | 'RESTRICT',
+  ): Promise<void> {
+    const rows = (await queryRunner.query(
+      `
+      SELECT con.conname
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid = con.conrelid
+      JOIN pg_attribute att
+        ON att.attrelid = con.conrelid AND att.attnum = ANY(con.conkey)
+      WHERE con.contype = 'f'
+        AND rel.relname = $1
+        AND att.attname = $2
+      `,
+      [table, column],
+    )) as Array<{ conname: string }>;
+
+    if (rows.length === 0) {
+      return;
+    }
+
+    const { conname } = rows[0];
+    await queryRunner.query(
+      `ALTER TABLE "${table}" DROP CONSTRAINT "${conname}"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${table}" ADD CONSTRAINT "${conname}" FOREIGN KEY ("${column}") REFERENCES "${refTable}"("id") ON DELETE ${onDelete}`,
+    );
+  }
+}

--- a/src/teams/teams.service.spec.ts
+++ b/src/teams/teams.service.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TeamsService } from './teams.service';
+import { Team, TeamMemberSplit, Bounty, User } from '../common/entities';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+
+describe('TeamsService', () => {
+  let service: TeamsService;
+  let teamRepo: any;
+  let splitRepo: any;
+  let bountyRepo: any;
+
+  beforeEach(async () => {
+    teamRepo = {
+      create: jest.fn((dto) => ({ id: 'team-uuid', ...dto })),
+      save: jest.fn((entity) => Promise.resolve({ id: 'team-uuid', ...entity })),
+      findOne: jest.fn(),
+    };
+    splitRepo = {
+      create: jest.fn((dto) => ({ id: 'split-uuid', ...dto })),
+      save: jest.fn((entity) => Promise.resolve({ id: 'split-uuid', ...entity })),
+    };
+    bountyRepo = {
+      findOne: jest.fn(),
+      save: jest.fn((entity) => Promise.resolve(entity)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TeamsService,
+        { provide: getRepositoryToken(Team), useValue: teamRepo },
+        { provide: getRepositoryToken(TeamMemberSplit), useValue: splitRepo },
+        { provide: getRepositoryToken(Bounty), useValue: bountyRepo },
+      ],
+    }).compile();
+
+    service = module.get<TeamsService>(TeamsService);
+  });
+
+  describe('create', () => {
+    it('creates a team and its splits when percentages sum to 100', async () => {
+      const dto = {
+        name: 'Alpha Team',
+        createdById: 'user-1',
+        members: [
+          { userId: 'user-1', percentage: 60, role: 'lead' },
+          { userId: 'user-2', percentage: 40, role: 'dev' },
+        ],
+      };
+
+      const result = await service.create(dto);
+      expect(result.name).toBe('Alpha Team');
+      expect(result.splits).toHaveLength(2);
+      expect(splitRepo.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects team creation if splits do not sum to 100', async () => {
+      const dto = {
+        name: 'Invalid Team',
+        members: [
+          { userId: 'user-1', percentage: 50 },
+          { userId: 'user-2', percentage: 30 },
+        ],
+      };
+
+      await expect(service.create(dto)).rejects.toThrow(BadRequestException);
+      expect(teamRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns team with splits relation', async () => {
+      const mockTeam = { id: 'team-1', name: 'Alpha', splits: [] };
+      teamRepo.findOne.mockResolvedValue(mockTeam);
+
+      const res = await service.findOne('team-1');
+      expect(res).toBe(mockTeam);
+      expect(teamRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'team-1' },
+        relations: { splits: true },
+      });
+    });
+
+    it('throws NotFoundException when team does not exist', async () => {
+      teamRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOne('non-existent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('assignToBounty', () => {
+    it('attaches team to bounty', async () => {
+      const mockTeam = { id: 'team-1', name: 'Alpha', splits: [] };
+      const mockBounty = { id: 'bounty-1', teamId: null };
+      teamRepo.findOne.mockResolvedValue(mockTeam);
+      bountyRepo.findOne.mockResolvedValue(mockBounty);
+
+      const res = await service.assignToBounty('team-1', 'bounty-1');
+      expect(res.teamId).toBe('team-1');
+      expect(bountyRepo.save).toHaveBeenCalledWith(expect.objectContaining({ teamId: 'team-1' }));
+    });
+  });
+});


### PR DESCRIPTION
## Overview
Closes #58.

This PR fixes a critical data-integrity gap where  used . When a  account was deleted, TypeORM/Postgres would cascade the deletion to remove their  row outright, silently leaving the remaining team splits summing to less than 100%. Subsequent calls to  would pass the invalid splits to , causing  to throw a  and stranding the bounty permanently in  with a  escrow.

## Changes Made
1. **Entity Definition**: Changed  relation from  to , treating team member splits as financial commitments that must not be silently removed.
2. **Database Migration**: Added  using the established  helper to safely update the live foreign key constraint on  without hardcoding TypeORM constraint names.
3. **Unit Tests**: Added comprehensive test suite  testing team creation, split percentage validation, , and .

## Deletion Policy Trade-off Analysis
- **Why RESTRICT**: A  is a financial commitment (a promised percentage of a bounty payout) in the same sense that a  is a record of moved funds. Using  guarantees database-level enforcement of the 100% split invariant.
- **Account Deletion / GDPR**: If a user genuinely requests account removal, their user record cannot be hard-deleted while bound to active team commitments. Instead, once bounties are finalized or if soft-delete/anonymization is performed (e.g. clearing PII fields while retaining the UUID foreign key), data integrity remains fully preserved.

## Validation
- : Compiles successfully with no TypeScript errors.
- : All 116 tests passing across 17 test suites.
