### PR TITLE
Add StrKey-backed Stellar address validation to all funder/recipient DTO fields

### DIFF
--- a/src/bounties/bounties.controller.ts
+++ b/src/bounties/bounties.controller.ts
@@ -1,14 +1,14 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
 import { BountiesService } from './bounties.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
 import { ClaimBountyDto } from './dto/claim-bounty.dto';
 import { BountyStatus } from '../common/enums';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
+import { IsStellarAddress } from '../common/validators/stellar-address.validator';
 
 class FundBountyDto {
-  @IsString()
+  @IsStellarAddress()
   funderAddress: string;
 }
 

--- a/src/common/validators/stellar-address.validator.ts
+++ b/src/common/validators/stellar-address.validator.ts
@@ -1,0 +1,35 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { StrKey } from '@stellar/stellar-sdk';
+
+/**
+ * Backed by the SDK's own StrKey checksum validation (base32 decode +
+ * version byte + CRC16 checksum over the payload) rather than a hand-rolled
+ * regex, so a syntactically-plausible-but-checksum-invalid address is
+ * rejected the same as an obviously malformed one (#60).
+ */
+export function isValidStellarAddress(value: unknown): value is string {
+  return typeof value === 'string' && StrKey.isValidEd25519PublicKey(value);
+}
+
+export function IsStellarAddress(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isStellarAddress',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          return isValidStellarAddress(value);
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid Stellar public key (StrKey-encoded Ed25519 address)`;
+        },
+      },
+    });
+  };
+}

--- a/src/escrow/dto/fund-escrow.dto.ts
+++ b/src/escrow/dto/fund-escrow.dto.ts
@@ -1,10 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsUUID } from 'class-validator';
 import { AssetType } from '../../common/enums';
 import {
   IsMoneyAmount,
   IsSupportedEscrowAsset,
 } from '../../common/validators/money.validator';
+import { IsStellarAddress } from '../../common/validators/stellar-address.validator';
 
 export class FundEscrowDto {
   @ApiProperty({ description: 'Amount to lock in the escrow contract' })
@@ -16,7 +17,7 @@ export class FundEscrowDto {
   asset: AssetType;
 
   @ApiProperty({ description: 'Stellar public key of the funding sponsor' })
-  @IsString()
+  @IsStellarAddress()
   funderAddress: string;
 
   @ApiProperty({ required: false })

--- a/src/escrow/dto/release-escrow.dto.ts
+++ b/src/escrow/dto/release-escrow.dto.ts
@@ -1,9 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsUUID } from 'class-validator';
+import { IsStellarAddress } from '../../common/validators/stellar-address.validator';
 
 export class ReleaseEscrowDto {
   @ApiProperty({ description: 'Stellar public key of the recipient' })
-  @IsString()
+  @IsStellarAddress()
   recipientAddress: string;
 
   @ApiProperty({ required: false })

--- a/src/escrow/dto/split-release.dto.ts
+++ b/src/escrow/dto/split-release.dto.ts
@@ -4,16 +4,16 @@ import {
   ArrayMinSize,
   IsNumber,
   IsOptional,
-  IsString,
   IsUUID,
   Max,
   Min,
   ValidateNested,
 } from 'class-validator';
+import { IsStellarAddress } from '../../common/validators/stellar-address.validator';
 
 export class SplitRecipientDto {
   @ApiProperty()
-  @IsString()
+  @IsStellarAddress()
   recipientAddress: string;
 
   @ApiProperty({ required: false })

--- a/src/maintenance-pool/maintenance-pool.controller.ts
+++ b/src/maintenance-pool/maintenance-pool.controller.ts
@@ -1,16 +1,17 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsUUID } from 'class-validator';
 import { MaintenancePoolService } from './maintenance-pool.service';
 import { CreatePoolDto } from './dto/create-pool.dto';
 import { IsMoneyAmount } from '../common/validators/money.validator';
+import { IsStellarAddress } from '../common/validators/stellar-address.validator';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
 
 class DepositDto {
   @IsMoneyAmount()
   amount: string;
 
-  @IsString()
+  @IsStellarAddress()
   funderAddress: string;
 }
 
@@ -18,7 +19,7 @@ class AssignRewardDto {
   @IsMoneyAmount()
   amount: string;
 
-  @IsString()
+  @IsStellarAddress()
   recipientAddress: string;
 
   @IsOptional()

--- a/src/milestones/milestones.controller.ts
+++ b/src/milestones/milestones.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsUUID } from 'class-validator';
 import { MilestonesService } from './milestones.service';
 import { CreateMilestoneDto } from './dto/create-milestone.dto';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
@@ -12,7 +12,7 @@ class FundMilestoneDto {
 }
 
 class ResolveIssueDto {
-  @IsString()
+  @IsStellarAddress()
   recipientAddress: string;
 
   @IsOptional()

--- a/src/milestones/milestones.controller.ts
+++ b/src/milestones/milestones.controller.ts
@@ -4,9 +4,10 @@ import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { MilestonesService } from './milestones.service';
 import { CreateMilestoneDto } from './dto/create-milestone.dto';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
+import { IsStellarAddress } from '../common/validators/stellar-address.validator';
 
 class FundMilestoneDto {
-  @IsString()
+  @IsStellarAddress()
   funderAddress: string;
 }
 

--- a/test/stellar-address-validation-bounties-milestones.e2e-spec.ts
+++ b/test/stellar-address-validation-bounties-milestones.e2e-spec.ts
@@ -1,0 +1,209 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { randomUUID } from 'crypto';
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
+import { BountiesController } from '../src/bounties/bounties.controller';
+import { BountiesService } from '../src/bounties/bounties.service';
+import { MilestonesController } from '../src/milestones/milestones.controller';
+import { MilestonesService } from '../src/milestones/milestones.service';
+import { IdempotencyKeyStatus } from '../src/common/enums';
+import { IdempotencyKey } from '../src/common/entities/idempotency-key.entity';
+import { IdempotencyInterceptor } from '../src/common/idempotency/idempotency.interceptor';
+
+/** Same in-memory stand-in used across this directory's e2e specs — see
+ * escrow-idempotency.e2e-spec.ts's FakeIdempotencyRepo for the rationale
+ * behind duplicating it per file instead of sharing one implementation. */
+class FakeIdempotencyRepo {
+  rows: Partial<IdempotencyKey>[] = [];
+
+  findOneBy(
+    where: Partial<IdempotencyKey>,
+  ): Promise<Partial<IdempotencyKey> | null> {
+    return Promise.resolve(
+      this.rows.find((r) =>
+        (Object.keys(where) as (keyof IdempotencyKey)[]).every(
+          (k) => r[k] === where[k],
+        ),
+      ) ?? null,
+    );
+  }
+
+  insert(data: Partial<IdempotencyKey>): Promise<void> {
+    this.rows.push({
+      ...data,
+      status: IdempotencyKeyStatus.PROCESSING,
+      responseStatus: null,
+      responseBody: null,
+      updatedAt: new Date(),
+    });
+    return Promise.resolve();
+  }
+
+  update(
+    criteria: Partial<IdempotencyKey>,
+    partial: Partial<IdempotencyKey>,
+  ): Promise<{ affected: number }> {
+    let affected = 0;
+    for (const row of this.rows) {
+      if (
+        (Object.keys(criteria) as (keyof IdempotencyKey)[]).every(
+          (k) => row[k] === criteria[k],
+        )
+      ) {
+        Object.assign(row, partial);
+        affected += 1;
+      }
+    }
+    return Promise.resolve({ affected });
+  }
+
+  delete(criteria: Partial<IdempotencyKey>): Promise<{ affected: number }> {
+    const before = this.rows.length;
+    this.rows = this.rows.filter(
+      (r) =>
+        !(Object.keys(criteria) as (keyof IdempotencyKey)[]).every(
+          (k) => r[k] === criteria[k],
+        ),
+    );
+    return Promise.resolve({ affected: before - this.rows.length });
+  }
+}
+
+function checksumInvalidAddress(): string {
+  const valid = Keypair.random().publicKey();
+  const flippedChar = valid[10] === 'A' ? 'B' : 'A';
+  const candidate = valid.slice(0, 10) + flippedChar + valid.slice(11);
+  if (StrKey.isValidEd25519PublicKey(candidate)) {
+    return checksumInvalidAddress();
+  }
+  return candidate;
+}
+
+function newFakeRepoProvider() {
+  return {
+    provide: getRepositoryToken(IdempotencyKey),
+    useValue: new FakeIdempotencyRepo(),
+  };
+}
+
+describe('Stellar address validation at the API boundary — bounties & milestones endpoints (#60)', () => {
+  let app: INestApplication;
+  let bountiesService: { fund: jest.Mock };
+  let milestonesService: { fund: jest.Mock; resolveIssue: jest.Mock };
+
+  beforeAll(async () => {
+    bountiesService = {
+      fund: jest.fn().mockResolvedValue({ id: 'bounty_1' }),
+    };
+    milestonesService = {
+      fund: jest.fn().mockResolvedValue({ id: 'milestone_1' }),
+      resolveIssue: jest.fn().mockResolvedValue({ id: 'milestone_1' }),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [BountiesController, MilestonesController],
+      providers: [
+        { provide: BountiesService, useValue: bountiesService },
+        { provide: MilestonesService, useValue: milestonesService },
+        IdempotencyInterceptor,
+        Reflector,
+        newFakeRepoProvider(),
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    bountiesService.fund.mockClear();
+    milestonesService.fund.mockClear();
+    milestonesService.resolveIssue.mockClear();
+  });
+
+  const badAddresses = () => [
+    '',
+    'not-an-address',
+    'G'.repeat(55),
+    checksumInvalidAddress(),
+  ];
+
+  it.each(badAddresses())(
+    'rejects POST /bounties/:id/fund with a malformed funderAddress (%p) as 400',
+    async (bad) => {
+      await request(app.getHttpServer())
+        .post('/bounties/bounty_1/fund')
+        .set('Idempotency-Key', randomUUID())
+        .send({ funderAddress: bad })
+        .expect(400);
+
+      expect(bountiesService.fund).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts POST /bounties/:id/fund with a valid funderAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/bounties/bounty_1/fund')
+      .set('Idempotency-Key', randomUUID())
+      .send({ funderAddress: Keypair.random().publicKey() })
+      .expect(201);
+
+    expect(bountiesService.fund).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(badAddresses())(
+    'rejects POST /milestones/:id/fund with a malformed funderAddress (%p) as 400',
+    async (bad) => {
+      await request(app.getHttpServer())
+        .post('/milestones/milestone_1/fund')
+        .set('Idempotency-Key', randomUUID())
+        .send({ funderAddress: bad })
+        .expect(400);
+
+      expect(milestonesService.fund).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts POST /milestones/:id/fund with a valid funderAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/milestones/milestone_1/fund')
+      .set('Idempotency-Key', randomUUID())
+      .send({ funderAddress: Keypair.random().publicKey() })
+      .expect(201);
+
+    expect(milestonesService.fund).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(badAddresses())(
+    'rejects POST /milestones/:id/issues/:issueId/resolve with a malformed recipientAddress (%p) as 400',
+    async (bad) => {
+      await request(app.getHttpServer())
+        .post('/milestones/milestone_1/issues/issue_1/resolve')
+        .set('Idempotency-Key', randomUUID())
+        .send({ recipientAddress: bad })
+        .expect(400);
+
+      expect(milestonesService.resolveIssue).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts POST /milestones/:id/issues/:issueId/resolve with a valid recipientAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/milestones/milestone_1/issues/issue_1/resolve')
+      .set('Idempotency-Key', randomUUID())
+      .send({ recipientAddress: Keypair.random().publicKey() })
+      .expect(201);
+
+    expect(milestonesService.resolveIssue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/stellar-address-validation-escrow.e2e-spec.ts
+++ b/test/stellar-address-validation-escrow.e2e-spec.ts
@@ -1,0 +1,228 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { randomUUID } from 'crypto';
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
+import { EscrowController } from '../src/escrow/escrow.controller';
+import { EscrowService } from '../src/escrow/escrow.service';
+import { AssetType, IdempotencyKeyStatus } from '../src/common/enums';
+import { IdempotencyKey } from '../src/common/entities/idempotency-key.entity';
+import { IdempotencyInterceptor } from '../src/common/idempotency/idempotency.interceptor';
+
+/**
+ * Same in-memory stand-in as escrow-idempotency.e2e-spec.ts's
+ * FakeIdempotencyRepo. Deliberately duplicated rather than shared — see
+ * that file's doc comment for why (separate rootDir per e2e-spec run).
+ */
+class FakeIdempotencyRepo {
+  rows: Partial<IdempotencyKey>[] = [];
+
+  findOneBy(
+    where: Partial<IdempotencyKey>,
+  ): Promise<Partial<IdempotencyKey> | null> {
+    return Promise.resolve(
+      this.rows.find((r) =>
+        (Object.keys(where) as (keyof IdempotencyKey)[]).every(
+          (k) => r[k] === where[k],
+        ),
+      ) ?? null,
+    );
+  }
+
+  insert(data: Partial<IdempotencyKey>): Promise<void> {
+    this.rows.push({
+      ...data,
+      status: IdempotencyKeyStatus.PROCESSING,
+      responseStatus: null,
+      responseBody: null,
+      updatedAt: new Date(),
+    });
+    return Promise.resolve();
+  }
+
+  update(
+    criteria: Partial<IdempotencyKey>,
+    partial: Partial<IdempotencyKey>,
+  ): Promise<{ affected: number }> {
+    let affected = 0;
+    for (const row of this.rows) {
+      if (
+        (Object.keys(criteria) as (keyof IdempotencyKey)[]).every(
+          (k) => row[k] === criteria[k],
+        )
+      ) {
+        Object.assign(row, partial);
+        affected += 1;
+      }
+    }
+    return Promise.resolve({ affected });
+  }
+
+  delete(criteria: Partial<IdempotencyKey>): Promise<{ affected: number }> {
+    const before = this.rows.length;
+    this.rows = this.rows.filter(
+      (r) =>
+        !(Object.keys(criteria) as (keyof IdempotencyKey)[]).every(
+          (k) => r[k] === criteria[k],
+        ),
+    );
+    return Promise.resolve({ affected: before - this.rows.length });
+  }
+}
+
+/** A right-length (56-char), StrKey-alphabet string whose checksum is invalid. */
+function checksumInvalidAddress(): string {
+  const valid = Keypair.random().publicKey();
+  const flippedChar = valid[10] === 'A' ? 'B' : 'A';
+  const candidate = valid.slice(0, 10) + flippedChar + valid.slice(11);
+  if (StrKey.isValidEd25519PublicKey(candidate)) {
+    // Vanishingly unlikely (a single-character flip landing on another
+    // valid checksum), but re-roll rather than risk a flaky assertion.
+    return checksumInvalidAddress();
+  }
+  return candidate;
+}
+
+describe('Stellar address validation at the API boundary — escrow endpoints (#60)', () => {
+  let app: INestApplication;
+  let escrowService: {
+    fund: jest.Mock;
+    release: jest.Mock;
+    splitRelease: jest.Mock;
+  };
+
+  beforeAll(async () => {
+    escrowService = {
+      fund: jest.fn().mockResolvedValue({ id: 'esc_1', status: 'locked' }),
+      release: jest.fn().mockResolvedValue({ id: 'esc_1', status: 'released' }),
+      splitRelease: jest.fn().mockResolvedValue([]),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [EscrowController],
+      providers: [
+        { provide: EscrowService, useValue: escrowService },
+        IdempotencyInterceptor,
+        Reflector,
+        {
+          provide: getRepositoryToken(IdempotencyKey),
+          useValue: new FakeIdempotencyRepo(),
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    // Mirrors main.ts's ValidationPipe config exactly — this is what
+    // actually enforces @IsStellarAddress() at the HTTP boundary; none of
+    // this repo's other e2e specs apply it, so it isn't inherited.
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    escrowService.fund.mockClear();
+    escrowService.release.mockClear();
+    escrowService.splitRelease.mockClear();
+  });
+
+  const badAddresses = () => [
+    '',
+    'not-an-address',
+    'G'.repeat(55), // wrong length
+    checksumInvalidAddress(),
+  ];
+
+  it.each(badAddresses())(
+    'rejects POST /escrow/fund with a malformed funderAddress (%p) as 400, never reaching EscrowService',
+    async (bad) => {
+      await request(app.getHttpServer())
+        .post('/escrow/fund')
+        .set('Idempotency-Key', randomUUID())
+        .send({
+          amount: '10.0000000',
+          asset: AssetType.USDC,
+          funderAddress: bad,
+          bountyId: '11111111-1111-4111-8111-111111111111',
+        })
+        .expect(400);
+
+      expect(escrowService.fund).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts POST /escrow/fund with a valid funderAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/escrow/fund')
+      .set('Idempotency-Key', randomUUID())
+      .send({
+        amount: '10.0000000',
+        asset: AssetType.USDC,
+        funderAddress: Keypair.random().publicKey(),
+        bountyId: '11111111-1111-4111-8111-111111111111',
+      })
+      .expect(201);
+
+    expect(escrowService.fund).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(badAddresses())(
+    'rejects POST /escrow/:id/release with a malformed recipientAddress (%p) as 400, never reaching EscrowService',
+    async (bad) => {
+      await request(app.getHttpServer())
+        .post('/escrow/esc_1/release')
+        .set('Idempotency-Key', randomUUID())
+        .send({ recipientAddress: bad })
+        .expect(400);
+
+      expect(escrowService.release).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts POST /escrow/:id/release with a valid recipientAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/escrow/esc_1/release')
+      .set('Idempotency-Key', randomUUID())
+      .send({ recipientAddress: Keypair.random().publicKey() })
+      .expect(201);
+
+    expect(escrowService.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects POST /escrow/:id/split-release when any recipient in the array has a malformed recipientAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/escrow/esc_1/split-release')
+      .set('Idempotency-Key', randomUUID())
+      .send({
+        recipients: [
+          { recipientAddress: Keypair.random().publicKey(), percentage: 50 },
+          { recipientAddress: checksumInvalidAddress(), percentage: 50 },
+        ],
+      })
+      .expect(400);
+
+    expect(escrowService.splitRelease).not.toHaveBeenCalled();
+  });
+
+  it('accepts POST /escrow/:id/split-release when every recipient has a valid recipientAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/escrow/esc_1/split-release')
+      .set('Idempotency-Key', randomUUID())
+      .send({
+        recipients: [
+          { recipientAddress: Keypair.random().publicKey(), percentage: 60 },
+          { recipientAddress: Keypair.random().publicKey(), percentage: 40 },
+        ],
+      })
+      .expect(201);
+
+    expect(escrowService.splitRelease).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/stellar-address-validation-maintenance-pool.e2e-spec.ts
+++ b/test/stellar-address-validation-maintenance-pool.e2e-spec.ts
@@ -1,0 +1,180 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { randomUUID } from 'crypto';
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
+import { MaintenancePoolController } from '../src/maintenance-pool/maintenance-pool.controller';
+import { MaintenancePoolService } from '../src/maintenance-pool/maintenance-pool.service';
+import { IdempotencyKeyStatus } from '../src/common/enums';
+import { IdempotencyKey } from '../src/common/entities/idempotency-key.entity';
+import { IdempotencyInterceptor } from '../src/common/idempotency/idempotency.interceptor';
+
+/** Same in-memory stand-in used across this directory's e2e specs — see
+ * escrow-idempotency.e2e-spec.ts's FakeIdempotencyRepo for the rationale
+ * behind duplicating it per file instead of sharing one implementation. */
+class FakeIdempotencyRepo {
+  rows: Partial<IdempotencyKey>[] = [];
+
+  findOneBy(
+    where: Partial<IdempotencyKey>,
+  ): Promise<Partial<IdempotencyKey> | null> {
+    return Promise.resolve(
+      this.rows.find((r) =>
+        (Object.keys(where) as (keyof IdempotencyKey)[]).every(
+          (k) => r[k] === where[k],
+        ),
+      ) ?? null,
+    );
+  }
+
+  insert(data: Partial<IdempotencyKey>): Promise<void> {
+    this.rows.push({
+      ...data,
+      status: IdempotencyKeyStatus.PROCESSING,
+      responseStatus: null,
+      responseBody: null,
+      updatedAt: new Date(),
+    });
+    return Promise.resolve();
+  }
+
+  update(
+    criteria: Partial<IdempotencyKey>,
+    partial: Partial<IdempotencyKey>,
+  ): Promise<{ affected: number }> {
+    let affected = 0;
+    for (const row of this.rows) {
+      if (
+        (Object.keys(criteria) as (keyof IdempotencyKey)[]).every(
+          (k) => row[k] === criteria[k],
+        )
+      ) {
+        Object.assign(row, partial);
+        affected += 1;
+      }
+    }
+    return Promise.resolve({ affected });
+  }
+
+  delete(criteria: Partial<IdempotencyKey>): Promise<{ affected: number }> {
+    const before = this.rows.length;
+    this.rows = this.rows.filter(
+      (r) =>
+        !(Object.keys(criteria) as (keyof IdempotencyKey)[]).every(
+          (k) => r[k] === criteria[k],
+        ),
+    );
+    return Promise.resolve({ affected: before - this.rows.length });
+  }
+}
+
+function checksumInvalidAddress(): string {
+  const valid = Keypair.random().publicKey();
+  const flippedChar = valid[10] === 'A' ? 'B' : 'A';
+  const candidate = valid.slice(0, 10) + flippedChar + valid.slice(11);
+  if (StrKey.isValidEd25519PublicKey(candidate)) {
+    return checksumInvalidAddress();
+  }
+  return candidate;
+}
+
+describe('Stellar address validation at the API boundary — maintenance-pool endpoints (#60)', () => {
+  let app: INestApplication;
+  let poolService: { deposit: jest.Mock; assignReward: jest.Mock };
+
+  beforeAll(async () => {
+    poolService = {
+      deposit: jest.fn().mockResolvedValue({ id: 'pool_1' }),
+      assignReward: jest.fn().mockResolvedValue({ id: 'pool_1' }),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [MaintenancePoolController],
+      providers: [
+        { provide: MaintenancePoolService, useValue: poolService },
+        IdempotencyInterceptor,
+        Reflector,
+        {
+          provide: getRepositoryToken(IdempotencyKey),
+          useValue: new FakeIdempotencyRepo(),
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    poolService.deposit.mockClear();
+    poolService.assignReward.mockClear();
+  });
+
+  const badAddresses = () => [
+    '',
+    'not-an-address',
+    'G'.repeat(55),
+    checksumInvalidAddress(),
+  ];
+
+  it.each(badAddresses())(
+    'rejects POST /maintenance-pools/:id/deposit with a malformed funderAddress (%p) as 400',
+    async (bad) => {
+      await request(app.getHttpServer())
+        .post('/maintenance-pools/pool_1/deposit')
+        .set('Idempotency-Key', randomUUID())
+        .send({ amount: '10.0000000', funderAddress: bad })
+        .expect(400);
+
+      expect(poolService.deposit).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts POST /maintenance-pools/:id/deposit with a valid funderAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/maintenance-pools/pool_1/deposit')
+      .set('Idempotency-Key', randomUUID())
+      .send({
+        amount: '10.0000000',
+        funderAddress: Keypair.random().publicKey(),
+      })
+      .expect(201);
+
+    expect(poolService.deposit).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(badAddresses())(
+    'rejects POST /maintenance-pools/:id/assign-reward with a malformed recipientAddress (%p) as 400',
+    async (bad) => {
+      await request(app.getHttpServer())
+        .post('/maintenance-pools/pool_1/assign-reward')
+        .set('Idempotency-Key', randomUUID())
+        .send({ amount: '5.0000000', recipientAddress: bad })
+        .expect(400);
+
+      expect(poolService.assignReward).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts POST /maintenance-pools/:id/assign-reward with a valid recipientAddress', async () => {
+    await request(app.getHttpServer())
+      .post('/maintenance-pools/pool_1/assign-reward')
+      .set('Idempotency-Key', randomUUID())
+      .send({
+        amount: '5.0000000',
+        recipientAddress: Keypair.random().publicKey(),
+      })
+      .expect(201);
+
+    expect(poolService.assignReward).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Every DTO field representing a Stellar public key — `funderAddress` on `FundEscrowDto`/`DepositDto`/`FundBountyDto`/`FundMilestoneDto`, `recipientAddress` on `ReleaseEscrowDto`/`SplitRecipientDto`/`AssignRewardDto`/`ResolveIssueDto` — was validated with nothing more than `@IsString()`. A malformed address (empty, syntactically invalid, wrong length, or checksum-invalid) fell through all the way to `SorobanClientService.toScVal`'s heuristic, which silently downgrades an unparseable "address-shaped" string to a generic string encoding instead of rejecting it — never producing a clean `400` anywhere in the pipeline.

- Added `IsStellarAddress()` in `src/common/validators/stellar-address.validator.ts`, mirroring the existing `IsMoneyAmount`/`IsSupportedEscrowAsset` pattern in `money.validator.ts`. Backed by `@stellar/stellar-sdk`'s own `StrKey.isValidEd25519PublicKey` (base32 decode + version byte + CRC16 checksum), not a hand-rolled regex.
- Applied it to every field the issue names explicitly, plus `ResolveIssueDto.recipientAddress` in the milestones controller — not named in the issue's own Requirements bullet list, but its Precise References section cites the exact line range containing it, and it flows into `escrowService.releasePartial` the same as every other `recipientAddress` field this issue targets. Leaving it out would have been an inconsistent, incomplete fix for the same gap.
- By the time execution reaches `SorobanClientService.toScVal`, every address it sees has already been validated — its silent try/catch fallback is no longer the only thing standing between a malformed address and a Soroban call.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (0 errors; pre-existing `no-unsafe-argument` warnings only, same pattern as the existing `escrow-idempotency.e2e-spec.ts`)
- [x] `npm run build`
- [x] `npm run test` — 130 passing; the only failure is `escrow-fk-integrity.integration.spec.ts`, which requires a real local Postgres (`role "postgres" does not exist` without one) — unrelated to this change, and CI provides a real Postgres service container so this isn't expected to fail there
- [x] `npm run test:e2e` — 41 passing across my 3 new e2e spec files (escrow, maintenance-pool, bounties/milestones) plus existing ones; the only failure is `app.e2e-spec.ts`, which needs real `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` to bootstrap the full `AppModule` — unrelated to this change (this repo's own CI conditionally skips e2e entirely when those secrets aren't configured)
- [x] New e2e tests (37 total, across `test/stellar-address-validation-{escrow,maintenance-pool,bounties-milestones}.e2e-spec.ts`) feed an empty string, a syntactically-invalid string, a wrong-length string, and a checksum-invalid-but-right-length string directly to every affected endpoint through a real Nest app with `ValidationPipe` applied (mirroring `main.ts`'s config — no existing e2e spec in this repo applies it, so it doesn't come for free), asserting `400` and that the underlying service is never called; each suite also confirms a freshly-generated valid `Keypair` address still passes through, so this isn't just testing the rejection path

Closes #60