### PR TITLE
fix(backend): validate apportionBasisPoints sum, pin node engines and fix dockerignore (#169, #173, #176)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,9 +32,6 @@ Thumbs.db
 
 # Documentation and configs not needed in production container
 README.md
-nest-cli.json
-tsconfig.json
-tsconfig.build.json
 eslint.config.mjs
 .prettierrc
 test/

--- a/package.json
+++ b/package.json
@@ -107,5 +107,8 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/src/escrow/split-math.util.spec.ts
+++ b/src/escrow/split-math.util.spec.ts
@@ -28,6 +28,13 @@ describe('apportionBasisPoints', () => {
   it('rejects an empty percentage list', () => {
     expect(() => apportionBasisPoints([])).toThrow(BadRequestException);
   });
+
+  it('rejects percentages that do not sum to 100', () => {
+    expect(() => apportionBasisPoints([20, 30])).toThrow(BadRequestException);
+    expect(() => apportionBasisPoints([50, 50, 10])).toThrow(
+      BadRequestException,
+    );
+  });
 });
 
 describe('splitStroops', () => {

--- a/src/escrow/split-math.util.ts
+++ b/src/escrow/split-math.util.ts
@@ -19,6 +19,13 @@ export function apportionBasisPoints(percentages: number[]): number[] {
     throw new BadRequestException('At least one percentage is required');
   }
 
+  const total = percentages.reduce((sum, p) => sum + p, 0);
+  if (Math.abs(total - 100) > 0.01) {
+    throw new BadRequestException(
+      `Percentages must sum to 100, got ${total.toFixed(2)}`,
+    );
+  }
+
   const bps = percentages.map((p) => Math.round(p * 100));
   const delta = TOTAL_BASIS_POINTS - bps.reduce((sum, b) => sum + b, 0);
 


### PR DESCRIPTION
### Summary of Changes

1. **Defensive validation in `apportionBasisPoints` (#169)**:
   - Added validation at the start of `apportionBasisPoints(percentages: number[])` to ensure `Math.abs(sum(percentages) - 100) <= 0.01`, throwing a clear `BadRequestException` when violated.
   - Added unit test cases verifying invalid sums are rejected as expected.

2. **Pin Node.js version in `package.json` engines (#173)**:
   - Added `"engines": { "node": ">=24" }` to `package.json` matching CI's `node-version: 24` and Docker's `node:24-alpine`.

3. **Restore Docker build configuration files in `.dockerignore` (#176)**:
   - Removed `tsconfig.json`, `tsconfig.build.json`, and `nest-cli.json` from `.dockerignore` so standalone Docker image builds (`docker build --target runner`) succeed without missing configuration.

### Validation
- `npm run test -- src/escrow/split-math.util.spec.ts` passes with 100% success.
- `npm run build` completed cleanly without errors.