### PR TITLE
fix(backend): protect analytics/reputation routes with JwtAuthGuard, add indexes on claimedById and webhook events, and enforce MaxLength on free-text DTOs (#138, #139, #148, #149, #151)

### DIFF
--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,12 +1,15 @@
-import { Controller, Get, Param } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { AnalyticsService } from './analytics.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('analytics')
 @Controller('analytics')
 export class AnalyticsController {
   constructor(private readonly analyticsService: AnalyticsService) {}
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Get('contributors/:userId')
   forContributor(@Param('userId') userId: string) {
     return this.analyticsService.forContributor(userId);

--- a/src/common/entities/bounty.entity.ts
+++ b/src/common/entities/bounty.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   OneToOne,
@@ -37,6 +38,7 @@ export class Bounty {
   @JoinColumn()
   claimedBy: User | null;
 
+  @Index()
   @Column({ type: 'varchar', nullable: true })
   claimedById: string | null;
 

--- a/src/common/entities/maintenance-pool.entity.ts
+++ b/src/common/entities/maintenance-pool.entity.ts
@@ -18,7 +18,7 @@ export class MaintenancePool {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
+  @Column({ type: 'varchar', length: 150 })
   name: string;
 
   @ManyToOne(() => Repository, { onDelete: 'CASCADE', nullable: true })

--- a/src/common/entities/milestone.entity.ts
+++ b/src/common/entities/milestone.entity.ts
@@ -27,10 +27,10 @@ export class Milestone {
   @Column()
   repositoryId: string;
 
-  @Column()
+  @Column({ type: 'varchar', length: 255 })
   title: string;
 
-  @Column({ type: 'text', nullable: true })
+  @Column({ type: 'varchar', length: 2000, nullable: true })
   description: string | null;
 
   @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })

--- a/src/common/entities/team-member-split.entity.ts
+++ b/src/common/entities/team-member-split.entity.ts
@@ -29,7 +29,7 @@ export class TeamMemberSplit {
   userId: string;
 
   /** Free-text label describing the member's contribution, e.g. "frontend". */
-  @Column({ type: 'varchar', nullable: true })
+  @Column({ type: 'varchar', length: 100, nullable: true })
   role: string | null;
 
   /** Percentage of the bounty payout, 0-100. Sum across a team must equal 100. */

--- a/src/common/entities/webhook-event.entity.ts
+++ b/src/common/entities/webhook-event.entity.ts
@@ -2,11 +2,14 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { WebhookEventStatus } from '../enums';
 
 /** Audit log of every inbound webhook, verified or not, for replay/debugging. */
+@Index(['eventType', 'status'])
+@Index(['status', 'receivedAt'])
 @Entity('webhook_events')
 export class WebhookEvent {
   @PrimaryGeneratedColumn('uuid')
@@ -37,6 +40,7 @@ export class WebhookEvent {
   @Column({ type: 'text', nullable: true })
   error: string | null;
 
+  @Index()
   @CreateDateColumn()
   receivedAt: Date;
 

--- a/src/maintenance-pool/dto/create-pool.dto.ts
+++ b/src/maintenance-pool/dto/create-pool.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
 import { AssetType } from '../../common/enums';
 import { IsSupportedEscrowAsset } from '../../common/validators/money.validator';
 
 export class CreatePoolDto {
   @ApiProperty()
   @IsString()
+  @MaxLength(150)
   name: string;
 
   @ApiProperty({ required: false })

--- a/src/milestones/dto/create-milestone.dto.ts
+++ b/src/milestones/dto/create-milestone.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsISO8601, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsISO8601, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
 import { AssetType } from '../../common/enums';
 import {
   IsMoneyAmount,
@@ -18,11 +18,13 @@ export class CreateMilestoneDto {
 
   @ApiProperty()
   @IsString()
+  @MaxLength(255)
   title: string;
 
   @ApiProperty({ required: false })
   @IsOptional()
   @IsString()
+  @MaxLength(2000)
   description?: string;
 
   @ApiProperty()

--- a/src/reputation/reputation.controller.ts
+++ b/src/reputation/reputation.controller.ts
@@ -1,22 +1,29 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { ReputationService } from './reputation.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('reputation')
 @Controller('reputation')
 export class ReputationController {
   constructor(private readonly reputationService: ReputationService) {}
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Post(':userId/recompute')
   recompute(@Param('userId') userId: string) {
     return this.reputationService.computeAndSave(userId);
   }
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Get(':userId')
   latest(@Param('userId') userId: string) {
     return this.reputationService.getLatest(userId);
   }
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Get(':userId/history')
   history(@Param('userId') userId: string) {
     return this.reputationService.history(userId);

--- a/src/teams/dto/create-team.dto.ts
+++ b/src/teams/dto/create-team.dto.ts
@@ -6,6 +6,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
   ValidateNested,
 } from 'class-validator';
 
@@ -17,6 +18,7 @@ export class TeamMemberSplitDto {
   @ApiProperty({ required: false, example: 'frontend' })
   @IsOptional()
   @IsString()
+  @MaxLength(100)
   role?: string;
 
   @ApiProperty({ example: 40 })
@@ -27,6 +29,7 @@ export class TeamMemberSplitDto {
 export class CreateTeamDto {
   @ApiProperty()
   @IsString()
+  @MaxLength(150)
   name: string;
 
   @ApiProperty({ required: false })


### PR DESCRIPTION
### Summary of Changes

This PR addresses multiple security, performance, and schema validation items across the backend:

1. **Authentication Guards on Analytics & Reputation Endpoints (#138, #139)**:
   - Added `@UseGuards(JwtAuthGuard)` and `@ApiBearerAuth()` to `AnalyticsController.forContributor` (`GET /analytics/contributors/:userId`), preventing unauthenticated scraping of contributor financial/performance profile data.
   - Added `@UseGuards(JwtAuthGuard)` and `@ApiBearerAuth()` to `ReputationController` across `POST /:userId/recompute`, `GET /:userId`, and `GET /:userId/history`, preventing unauthenticated denial-of-service / duplicate snapshot writes and information exposure.

2. **Database Performance Indexing (#148, #149)**:
   - Added `@Index()` on `Bounty.claimedById` (`src/common/entities/bounty.entity.ts`), speeding up critical contributor lookups in `ReputationService` and `AnalyticsService`.
   - Added composite indexes `@Index(["eventType", "status"])`, `@Index(["status", "receivedAt"])`, and single index on `receivedAt` in `WebhookEvent` (`src/common/entities/webhook-event.entity.ts`) for query performance over ever-growing webhook audit logs.

3. **String Length Range & DTO Constraints (#151)**:
   - Enforced `@MaxLength(100)` on `TeamMemberSplitDto.role` and matching `length: 100` on `TeamMemberSplit.role`.
   - Enforced `@MaxLength(150)` on `CreateTeamDto.name`.
   - Enforced `@MaxLength(255)` on `CreateMilestoneDto.title` and `@MaxLength(2000)` on `description`, with corresponding column lengths in `Milestone` entity.
   - Enforced `@MaxLength(150)` on `CreatePoolDto.name` and corresponding column length in `MaintenancePool` entity.

### Validation
- Ran full test suite (`npm test` excluding disconnected Postgres DB integration specs): all 20 test suites and 163 unit tests passed cleanly.
- Tested compilation (`npm run build`): clean build.

Closes #138, Closes #139, Closes #148, Closes #149, Closes #151
