### PR TITLE
fix(webhooks): ignore unhandled event types

### DIFF
--- a/src/github/github-webhooks.service.spec.ts
+++ b/src/github/github-webhooks.service.spec.ts
@@ -83,6 +83,23 @@ describe('GithubWebhooksService', () => {
     expect(bountiesService.markMergedAndRelease).not.toHaveBeenCalled();
   });
 
+  it.each(['push', 'ping', 'unknown_event'])(
+    'ignores a verified %s event when no handler is registered',
+    async (eventType) => {
+      const event = await service.handleEvent(
+        eventType,
+        'delivery-unhandled',
+        {},
+        true,
+      );
+
+      expect(event.status).toBe(WebhookEventStatus.IGNORED);
+      expect(event.processedAt).toBeUndefined();
+      expect(syncService.findRepositoryByGithubId).not.toHaveBeenCalled();
+      expect(bountiesService.markMergedAndRelease).not.toHaveBeenCalled();
+    },
+  );
+
   it('processes a merged pull_request event and releases the linked bounty', async () => {
     issueRepo.findOne.mockResolvedValue({
       id: 'issue-1',
@@ -279,6 +296,7 @@ describe('GithubWebhooksService', () => {
         payload.issue,
       );
       expect(event.status).toBe(WebhookEventStatus.PROCESSED);
+      expect(event.processedAt).toBeInstanceOf(Date);
     });
 
     it('ignores events for a repository this app is not tracking, without erroring', async () => {

--- a/src/github/github-webhooks.service.ts
+++ b/src/github/github-webhooks.service.ts
@@ -99,14 +99,14 @@ export class GithubWebhooksService {
           payload as unknown as GithubPullRequestPayload,
         );
         this.applyPullRequestOutcomes(event, outcomes);
-      } else {
-        if (eventType === 'issues') {
-          await this.handleIssueEvent(
-            payload as unknown as GithubIssuesEventPayload,
-          );
-        }
+      } else if (eventType === 'issues') {
+        await this.handleIssueEvent(
+          payload as unknown as GithubIssuesEventPayload,
+        );
         event.status = WebhookEventStatus.PROCESSED;
         event.processedAt = new Date();
+      } else {
+        event.status = WebhookEventStatus.IGNORED;
       }
     } catch (err) {
       event.status = WebhookEventStatus.FAILED;


### PR DESCRIPTION
Fixes #124.

`handleEvent` unconditionally marked every verified event in its non-`pull_request` branch as `PROCESSED`, even though only `issues` ran a handler there. This change makes `issues` the second handled branch and marks all other verified event types `IGNORED` without setting `processedAt`. Existing `pull_request`, `issues`, and invalid-signature behavior is preserved.

Tests:
- `node node_modules/jest/bin/jest.js src/github/github-webhooks.service.spec.ts --runInBand` (12 passed)
- `node node_modules/jest/bin/jest.js src/github --runInBand` (34 passed)
- `node node_modules/jest/bin/jest.js --runInBand --testPathIgnorePatterns=integration` (166 passed)
- `node node_modules/eslint/bin/eslint.js "{src,apps,libs,test}/**/*.ts" --fix` (0 errors; 22 pre-existing e2e warnings)
- `node node_modules/@nestjs/cli/bin/nest.js build`

I couldn't run the seven Postgres integration tests locally because this environment has no Docker/Postgres. The remaining 169 tests passed in the full Jest run; CI provides Postgres 16.