### PR TITLE
fix(bounties): throw BadRequestException when releasing team bounty with empty splits

### DIFF
--- a/src/bounties/bounties.service.spec.ts
+++ b/src/bounties/bounties.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { BountiesService } from './bounties.service';
@@ -141,6 +142,88 @@ describe('BountiesService', () => {
       'GCONTRIB',
       'contributor-1',
     );
+    expect(bounty.status).toBe(BountyStatus.PAID);
+  });
+
+  it('markMergedAndRelease throws BadRequestException if team has no member splits', async () => {
+    bountyRepo.findOne.mockResolvedValue({
+      id: 'b-team',
+      status: BountyStatus.IN_REVIEW,
+      escrowId: 'escrow-team',
+      claimedById: null,
+      teamId: 'team-empty',
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BountiesService,
+        { provide: getRepositoryToken(Bounty), useValue: bountyRepo },
+        { provide: getRepositoryToken(User), useValue: { findOne: jest.fn() } },
+        {
+          provide: getRepositoryToken(Team),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({
+              id: 'team-empty',
+              splits: [],
+            }),
+          },
+        },
+        { provide: EscrowService, useValue: escrowService },
+      ],
+    }).compile();
+    service = module.get(BountiesService);
+
+    await expect(service.markMergedAndRelease('b-team')).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(escrowService.splitRelease).not.toHaveBeenCalled();
+  });
+
+  it('markMergedAndRelease releases split to team members when splits exist', async () => {
+    bountyRepo.findOne.mockResolvedValue({
+      id: 'b-team-valid',
+      status: BountyStatus.IN_REVIEW,
+      escrowId: 'escrow-team-valid',
+      claimedById: null,
+      teamId: 'team-1',
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BountiesService,
+        { provide: getRepositoryToken(Bounty), useValue: bountyRepo },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({
+              id: 'u1',
+              stellarAddress: 'GSTELLAR1',
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(Team),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({
+              id: 'team-1',
+              splits: [{ userId: 'u1', percentage: 100 }],
+            }),
+          },
+        },
+        { provide: EscrowService, useValue: escrowService },
+      ],
+    }).compile();
+    service = module.get(BountiesService);
+
+    const bounty = await service.markMergedAndRelease('b-team-valid');
+
+    expect(escrowService.splitRelease).toHaveBeenCalledWith('escrow-team-valid', [
+      {
+        recipientId: 'u1',
+        recipientAddress: 'GSTELLAR1',
+        percentage: 100,
+      },
+    ]);
     expect(bounty.status).toBe(BountyStatus.PAID);
   });
 });

--- a/src/bounties/bounties.service.ts
+++ b/src/bounties/bounties.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Bounty, Team, User } from '../common/entities';
@@ -103,21 +103,24 @@ export class BountiesService {
         where: { id: bounty.teamId },
         relations: { splits: true },
       });
-      if (team && team.splits.length > 0) {
-        const recipients = await Promise.all(
-          team.splits.map(async (split) => {
-            const user = await this.userRepo.findOne({
-              where: { id: split.userId },
-            });
-            return {
-              recipientId: split.userId,
-              recipientAddress: user?.stellarAddress ?? '',
-              percentage: Number(split.percentage),
-            };
-          }),
+      if (!team || !team.splits || team.splits.length === 0) {
+        throw new BadRequestException(
+          `Cannot release bounty ${id}: assigned team ${bounty.teamId} has no member splits`,
         );
-        await this.escrowService.splitRelease(bounty.escrowId, recipients);
       }
+      const recipients = await Promise.all(
+        team.splits.map(async (split) => {
+          const user = await this.userRepo.findOne({
+            where: { id: split.userId },
+          });
+          return {
+            recipientId: split.userId,
+            recipientAddress: user?.stellarAddress ?? '',
+            percentage: Number(split.percentage),
+          };
+        }),
+      );
+      await this.escrowService.splitRelease(bounty.escrowId, recipients);
     } else if (bounty.claimedById) {
       const contributor = await this.userRepo.findOne({
         where: { id: bounty.claimedById },


### PR DESCRIPTION
Fixes #102

## Summary
- In `BountiesService.markMergedAndRelease`, throw `BadRequestException` when an assigned team has zero member splits (`!team || !team.splits || team.splits.length === 0`) instead of silently skipping `splitRelease` and erroneously transitioning the bounty status to `PAID`.
- Added unit tests in `src/bounties/bounties.service.spec.ts` asserting:
  1. `markMergedAndRelease` throws `BadRequestException` and prevents escrow release / transition to `PAID` when `team.splits` is empty.
  2. `markMergedAndRelease` performs split release as expected when valid splits exist.

## Verification
```bash
npx jest src/bounties/bounties.service.spec.ts
# 8 passed, 8 total (100%)
npx jest src/teams/ src/escrow/ src/github/
# 85 passed, 85 total across 10 test suites
```

/claim #102

### 💰 Payout Details
- **USDC (Solana)**: `6UvBhyhY6ayeoJEGZxK4bDoFAHd9yeRDTVusnoDGdgQ5`
- **USDT (TRON / TRC20)**: `TYcNrMSoY36q8WrsFSZyB26Rkj25EFgQsX`
