### PR TITLE
fix: wire LOG_LEVEL, enable strict TS, add idempotent + query validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,4 +66,5 @@ USDC_ASSET_CODE=USDC
 USDC_ASSET_ISSUER=
 
 # --- Misc --------------------------------------------------------------
+# NestJS log verbosity: error | warn | log | debug | verbose
 LOG_LEVEL=debug

--- a/src/bounties/bounties.controller.ts
+++ b/src/bounties/bounties.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseEnumPipe, Post, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { BountiesService } from './bounties.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
@@ -17,13 +17,14 @@ class FundBountyDto {
 export class BountiesController {
   constructor(private readonly bountiesService: BountiesService) {}
 
+  @Idempotent('bounty.create')
   @Post()
   create(@Body() dto: CreateBountyDto) {
     return this.bountiesService.create(dto);
   }
 
   @Get()
-  list(@Query('status') status?: BountyStatus) {
+  list(@Query('status', new ParseEnumPipe(BountyStatus, { optional: true })) status?: BountyStatus) {
     return this.bountiesService.list(status);
   }
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -3,6 +3,7 @@ export interface AppConfig {
   port: number;
   appUrl: string;
   frontendUrl: string;
+  logLevel: string;
   database: {
     url: string;
     synchronize: boolean;
@@ -38,6 +39,7 @@ export default (): AppConfig => ({
   port: parseInt(process.env.PORT ?? '3000', 10),
   appUrl: process.env.APP_URL ?? 'http://localhost:3000',
   frontendUrl: process.env.FRONTEND_URL ?? 'http://localhost:3001',
+  logLevel: process.env.LOG_LEVEL ?? 'debug',
   database: {
     url:
       process.env.DATABASE_URL ??

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, LoggerService, Logger } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
@@ -8,6 +8,18 @@ import { AppConfig } from './config/configuration';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 
 const INSECURE_DEFAULT_JWT_SECRET = 'insecure-dev-secret';
+
+const LOG_LEVEL_MAP: Record<string, string[]> = {
+  error: ['error'],
+  warn: ['error', 'warn'],
+  log: ['error', 'warn', 'log'],
+  debug: ['error', 'warn', 'log', 'debug'],
+  verbose: ['error', 'warn', 'log', 'debug', 'verbose'],
+};
+
+function resolveLogLevels(level: string): string[] {
+  return LOG_LEVEL_MAP[level.toLowerCase()] ?? LOG_LEVEL_MAP.log;
+}
 
 async function bootstrap() {
   // rawBody: true preserves the raw request buffer on req.rawBody, which the
@@ -17,6 +29,8 @@ async function bootstrap() {
   const configService = app.get(ConfigService<AppConfig, true>);
 
   const env = configService.get('env', { infer: true });
+  const logLevel = configService.get('logLevel', { infer: true });
+  app.useLogger(resolveLogLevels(logLevel));
   const jwtSecret = configService.get('jwt', { infer: true }).secret;
   if (env === 'production' && jwtSecret === INSECURE_DEFAULT_JWT_SECRET) {
     throw new Error(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,10 +16,8 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": true,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": true,
-    "strictBindCallApply": true,
     "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
Closes #100, Closes #101, Closes #103, Closes #104

## What changed
- **#100** — Wired `LOG_LEVEL` env var into NestJS logger. Added `logLevel` to `AppConfig`, mapped string values (`error`/`warn`/`log`/`debug`/`verbose`) to NestJS log-level arrays, and applied via `app.useLogger()` in `main.ts`. Added comment to `.env.example` documenting the option.
- **#101** — Enabled `"strict": true` in `tsconfig.json`, replacing the individual `strictNullChecks`, `noImplicitAny`, and `strictBindCallApply` flags. This also enables `strictFunctionTypes`, `strictPropertyInitialization`, `alwaysStrict`, `useUnknownInCatchVariables`, and `noImplicitThis`.
- **#103** — Added `@Idempotent('bounty.create')` to `BountiesController.create`, consistent with the other mutation routes (`fund`, `claim`, `refund`). Prevents opaque 500 errors on client retries.
- **#104** — Added `ParseEnumPipe(BountyStatus, { optional: true })` to `BountiesController.list` status query parameter. Invalid status values now return a clean 400 instead of a raw database error.

## How to test
- Set `LOG_LEVEL=error` in `.env`, restart, verify only errors are logged
- Remove individual strict flags from tsconfig, run `npx tsc --noEmit` to verify no new errors
- Retry a bounty create request with the same `Idempotency-Key` header, verify it returns the existing bounty instead of a 500
- `GET /api/bounties?status=nonsense` should return 400 with a validation error message