### PR TITLE
fix: JWT type, batch N+1 queries, PR closed handler, and test coverage

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -19,7 +19,7 @@ import { AppConfig } from '../config/configuration';
         const jwt = configService.get('jwt', { infer: true });
         return {
           secret: jwt.secret,
-          signOptions: { expiresIn: jwt.expiresIn as unknown as number },
+          signOptions: { expiresIn: jwt.expiresIn as string | number },
         };
       },
     }),

--- a/src/bounties/bounties.service.spec.ts
+++ b/src/bounties/bounties.service.spec.ts
@@ -8,11 +8,20 @@ import { InvalidBountyTransitionError } from './bounty-state-machine';
 
 describe('BountiesService', () => {
   let service: BountiesService;
-  let bountyRepo: { findOne: jest.Mock; save: jest.Mock; create: jest.Mock };
+  let bountyRepo: {
+    findOne: jest.Mock;
+    save: jest.Mock;
+    create: jest.Mock;
+    find: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let userRepo: { findOne: jest.Mock; find: jest.Mock };
+  let teamRepo: { findOne: jest.Mock };
   let escrowService: {
     fund: jest.Mock;
     release: jest.Mock;
     splitRelease: jest.Mock;
+    refund: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -24,19 +33,24 @@ describe('BountiesService', () => {
         status: BountyStatus.OPEN,
         ...data,
       })),
+      find: jest.fn(),
+      createQueryBuilder: jest.fn(),
     };
+    userRepo = { findOne: jest.fn(), find: jest.fn() };
+    teamRepo = { findOne: jest.fn() };
     escrowService = {
       fund: jest.fn().mockResolvedValue({ id: 'escrow-1', status: 'locked' }),
       release: jest.fn().mockResolvedValue(undefined),
       splitRelease: jest.fn().mockResolvedValue([]),
+      refund: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BountiesService,
         { provide: getRepositoryToken(Bounty), useValue: bountyRepo },
-        { provide: getRepositoryToken(User), useValue: { findOne: jest.fn() } },
-        { provide: getRepositoryToken(Team), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Team), useValue: teamRepo },
         { provide: EscrowService, useValue: escrowService },
       ],
     }).compile();
@@ -114,25 +128,10 @@ describe('BountiesService', () => {
       claimedById: 'contributor-1',
       teamId: null,
     });
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        BountiesService,
-        { provide: getRepositoryToken(Bounty), useValue: bountyRepo },
-        {
-          provide: getRepositoryToken(User),
-          useValue: {
-            findOne: jest.fn().mockResolvedValue({
-              id: 'contributor-1',
-              stellarAddress: 'GCONTRIB',
-            }),
-          },
-        },
-        { provide: getRepositoryToken(Team), useValue: { findOne: jest.fn() } },
-        { provide: EscrowService, useValue: escrowService },
-      ],
-    }).compile();
-    service = module.get(BountiesService);
+    userRepo.findOne.mockResolvedValue({
+      id: 'contributor-1',
+      stellarAddress: 'GCONTRIB',
+    });
 
     const bounty = await service.markMergedAndRelease('b1');
 
@@ -142,5 +141,111 @@ describe('BountiesService', () => {
       'contributor-1',
     );
     expect(bounty.status).toBe(BountyStatus.PAID);
+  });
+
+  it('markMergedAndRelease batches user lookups for team splits', async () => {
+    bountyRepo.findOne.mockResolvedValue({
+      id: 'b1',
+      status: BountyStatus.IN_REVIEW,
+      escrowId: 'escrow-1',
+      claimedById: null,
+      teamId: 'team-1',
+    });
+    teamRepo.findOne.mockResolvedValue({
+      id: 'team-1',
+      splits: [
+        { userId: 'u1', percentage: 60 },
+        { userId: 'u2', percentage: 40 },
+      ],
+    });
+    userRepo.find.mockResolvedValue([
+      { id: 'u1', stellarAddress: 'GADDR1' },
+      { id: 'u2', stellarAddress: 'GADDR2' },
+    ]);
+
+    const bounty = await service.markMergedAndRelease('b1');
+
+    expect(userRepo.find).toHaveBeenCalledTimes(1);
+    const findCall = userRepo.find.mock.calls[0][0];
+    expect(findCall.where.id._value).toEqual(
+      expect.arrayContaining(['u1', 'u2']),
+    );
+    expect(escrowService.splitRelease).toHaveBeenCalledWith('escrow-1', [
+      { recipientId: 'u1', recipientAddress: 'GADDR1', percentage: 60 },
+      { recipientId: 'u2', recipientAddress: 'GADDR2', percentage: 40 },
+    ]);
+    expect(bounty.status).toBe(BountyStatus.PAID);
+  });
+
+  it('refund calls escrowService.refund and moves bounty to REFUNDED', async () => {
+    bountyRepo.findOne.mockResolvedValue({
+      id: 'b1',
+      status: BountyStatus.FUNDED,
+      escrowId: 'escrow-1',
+    });
+
+    const bounty = await service.refund('b1');
+
+    expect(escrowService.refund).toHaveBeenCalledWith('escrow-1');
+    expect(bounty.status).toBe(BountyStatus.REFUNDED);
+  });
+
+  it('refund skips escrow refund when no escrow is linked', async () => {
+    bountyRepo.findOne.mockResolvedValue({
+      id: 'b1',
+      status: BountyStatus.OPEN,
+      escrowId: null,
+    });
+
+    const bounty = await service.refund('b1');
+
+    expect(escrowService.refund).not.toHaveBeenCalled();
+    expect(bounty.status).toBe(BountyStatus.REFUNDED);
+  });
+
+  it('expireOverdue flips overdue bounties to EXPIRED and returns count', async () => {
+    const overdueBounties = [
+      { id: 'b1', status: BountyStatus.OPEN },
+      { id: 'b2', status: BountyStatus.FUNDED },
+    ];
+    const mockQueryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(overdueBounties),
+    };
+    bountyRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+    const count = await service.expireOverdue();
+
+    expect(count).toBe(2);
+    expect(bountyRepo.save).toHaveBeenCalledTimes(2);
+    expect(overdueBounties[0].status).toBe(BountyStatus.EXPIRED);
+    expect(overdueBounties[1].status).toBe(BountyStatus.EXPIRED);
+  });
+
+  it('markPrClosedWithoutMerge transitions IN_REVIEW back to CLAIMED', async () => {
+    bountyRepo.findOne.mockResolvedValue({
+      id: 'b1',
+      status: BountyStatus.IN_REVIEW,
+      prUrl: 'https://github.com/x/y/pull/1',
+      prNumber: 1,
+    });
+
+    const bounty = await service.markPrClosedWithoutMerge('b1');
+
+    expect(bounty.status).toBe(BountyStatus.CLAIMED);
+    expect(bounty.prUrl).toBeNull();
+    expect(bounty.prNumber).toBeNull();
+  });
+
+  it('markPrClosedWithoutMerge rejects bounties not in IN_REVIEW', async () => {
+    bountyRepo.findOne.mockResolvedValue({
+      id: 'b1',
+      status: BountyStatus.CLAIMED,
+    });
+
+    await expect(service.markPrClosedWithoutMerge('b1')).rejects.toThrow(
+      InvalidBountyTransitionError,
+    );
   });
 });

--- a/src/bounties/bounties.service.ts
+++ b/src/bounties/bounties.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Bounty, Team, User } from '../common/entities';
 import { BountyStatus } from '../common/enums';
 import { assertTransition } from './bounty-state-machine';
@@ -80,6 +80,17 @@ export class BountiesService {
     return this.bountyRepo.save(bounty);
   }
 
+  /** The linked PR was closed without merging — move bounty back to CLAIMED. */
+  async markPrClosedWithoutMerge(id: string): Promise<Bounty> {
+    const bounty = await this.findOne(id);
+    assertTransition(bounty.status, BountyStatus.CLAIMED);
+
+    bounty.status = BountyStatus.CLAIMED;
+    bounty.prUrl = null;
+    bounty.prNumber = null;
+    return this.bountyRepo.save(bounty);
+  }
+
   /**
    * The linked PR was merged on GitHub. Transitions to MERGED and immediately
    * triggers the escrow release (single recipient or team split), moving to
@@ -104,18 +115,19 @@ export class BountiesService {
         relations: { splits: true },
       });
       if (team && team.splits.length > 0) {
-        const recipients = await Promise.all(
-          team.splits.map(async (split) => {
-            const user = await this.userRepo.findOne({
-              where: { id: split.userId },
-            });
-            return {
-              recipientId: split.userId,
-              recipientAddress: user?.stellarAddress ?? '',
-              percentage: Number(split.percentage),
-            };
-          }),
-        );
+        const userIds = team.splits.map((s) => s.userId);
+        const users = await this.userRepo.find({
+          where: { id: In(userIds) },
+        });
+        const userMap = new Map(users.map((u) => [u.id, u]));
+        const recipients = team.splits.map((split) => {
+          const user = userMap.get(split.userId);
+          return {
+            recipientId: split.userId,
+            recipientAddress: user?.stellarAddress ?? '',
+            percentage: Number(split.percentage),
+          };
+        });
         await this.escrowService.splitRelease(bounty.escrowId, recipients);
       }
     } else if (bounty.claimedById) {

--- a/src/github/github-webhooks.service.spec.ts
+++ b/src/github/github-webhooks.service.spec.ts
@@ -16,6 +16,7 @@ describe('GithubWebhooksService', () => {
   let bountiesService: {
     markInReview: jest.Mock;
     markMergedAndRelease: jest.Mock;
+    markPrClosedWithoutMerge: jest.Mock;
   };
   let syncService: {
     findRepositoryByGithubId: jest.Mock;
@@ -35,6 +36,7 @@ describe('GithubWebhooksService', () => {
     bountiesService = {
       markInReview: jest.fn().mockResolvedValue(undefined),
       markMergedAndRelease: jest.fn().mockResolvedValue(undefined),
+      markPrClosedWithoutMerge: jest.fn().mockResolvedValue(undefined),
     };
     syncService = {
       findRepositoryByGithubId: jest.fn(),
@@ -120,7 +122,13 @@ describe('GithubWebhooksService', () => {
     expect(event.status).toBe(WebhookEventStatus.PROCESSED);
   });
 
-  it('ignores a closed-but-not-merged pull_request event', async () => {
+  it('handles a closed-but-not-merged PR by moving linked bounties back to CLAIMED', async () => {
+    issueRepo.findOne.mockResolvedValue({
+      id: 'issue-1',
+      bounty: { id: 'bounty-1' },
+    });
+    bountyRepo.findOne.mockResolvedValue({ id: 'bounty-1', status: 'in_review' });
+
     const payload = {
       action: 'closed',
       number: 8,
@@ -132,8 +140,32 @@ describe('GithubWebhooksService', () => {
       },
       repository: { id: 1, full_name: 'a/b' },
     };
-    await service.handleEvent('pull_request', 'delivery-3', payload, true);
+    const event = await service.handleEvent('pull_request', 'delivery-3', payload, true);
+    expect(bountiesService.markPrClosedWithoutMerge).toHaveBeenCalledWith('bounty-1');
     expect(bountiesService.markMergedAndRelease).not.toHaveBeenCalled();
+    expect(event.status).toBe(WebhookEventStatus.PROCESSED);
+  });
+
+  it('skips bounty reset for closed-but-not-merged PR when bounty is not IN_REVIEW', async () => {
+    issueRepo.findOne.mockResolvedValue({
+      id: 'issue-1',
+      bounty: { id: 'bounty-1' },
+    });
+    bountyRepo.findOne.mockResolvedValue({ id: 'bounty-1', status: 'claimed' });
+
+    const payload = {
+      action: 'closed',
+      number: 8,
+      pull_request: {
+        html_url: 'x',
+        number: 8,
+        merged: false,
+        body: 'closes #1',
+      },
+      repository: { id: 1, full_name: 'a/b' },
+    };
+    await service.handleEvent('pull_request', 'delivery-3b', payload, true);
+    expect(bountiesService.markPrClosedWithoutMerge).not.toHaveBeenCalled();
   });
 
   describe('per-linked-issue isolation on a merged PR (#47)', () => {

--- a/src/github/github-webhooks.service.ts
+++ b/src/github/github-webhooks.service.ts
@@ -159,6 +159,10 @@ export class GithubWebhooksService {
   private async handlePullRequest(
     payload: GithubPullRequestPayload,
   ): Promise<LinkedIssueOutcome[]> {
+    if (payload.action === 'closed' && !payload.pull_request.merged) {
+      return this.handlePullRequestClosedWithoutMerge(payload);
+    }
+
     if (payload.action !== 'closed' || !payload.pull_request.merged) {
       return [];
     }
@@ -264,5 +268,57 @@ export class GithubWebhooksService {
   private extractLinkedIssueNumbers(body: string): number[] {
     const matches = [...body.matchAll(CLOSING_KEYWORD_RE)];
     return matches.map((m) => parseInt(m[3], 10));
+  }
+
+  /**
+   * When a PR is closed without merging, move linked bounties from
+   * IN_REVIEW back to CLAIMED so they become claimable again.
+   */
+  private async handlePullRequestClosedWithoutMerge(
+    payload: GithubPullRequestPayload,
+  ): Promise<LinkedIssueOutcome[]> {
+    const issueNumbers = [
+      ...new Set(
+        this.extractLinkedIssueNumbers(payload.pull_request.body ?? ''),
+      ),
+    ];
+    if (issueNumbers.length === 0) {
+      return [];
+    }
+
+    const outcomes: LinkedIssueOutcome[] = [];
+    for (const number of issueNumbers) {
+      try {
+        const issue = await this.issueRepo.findOne({
+          where: {
+            number,
+            repository: { githubRepoId: String(payload.repository.id) },
+          },
+          relations: { repository: true, bounty: true },
+        });
+        if (!issue?.bounty) {
+          outcomes.push({ issueNumber: number, outcome: 'skipped' });
+          continue;
+        }
+
+        const bounty = await this.bountyRepo.findOne({
+          where: { id: issue.bounty.id },
+        });
+        if (!bounty || bounty.status !== BountyStatus.IN_REVIEW) {
+          outcomes.push({ issueNumber: number, outcome: 'skipped' });
+          continue;
+        }
+
+        await this.bountiesService.markPrClosedWithoutMerge(bounty.id);
+        outcomes.push({ issueNumber: number, outcome: 'succeeded' });
+      } catch (err) {
+        outcomes.push({
+          issueNumber: number,
+          outcome: 'failed',
+          error: (err as Error).message,
+        });
+      }
+    }
+    return outcomes;
   }
 }


### PR DESCRIPTION
Fixes #98, Fixes #105, Fixes #106, Fixes #107

## What changed
- **#98** — Replace `as unknown as number` with `as string | number` for JWT expiresIn in auth module
- **#105** — Batch user lookups in `markMergedAndRelease` team-split path using a single `find({ where: { id: In(userIds) } })` instead of N individual queries
- **#107** — Add `markPrClosedWithoutMerge` method and handle `pull_request` `closed && !merged` webhook events to transition IN_REVIEW bounties back to CLAIMED
- **#106** — Add tests for `refund()`, `expireOverdue()`, team-split `markMergedAndRelease`, and PR closed without merge behavior (22 tests passing)

## Why
- #98: Misleading type cast masks potential bugs and erodes strictNullChecks value
- #105: N+1 queries add avoidable latency in the critical payout path
- #107: Bounties permanently stuck IN_REVIEW when PRs are closed without merge
- #106: Zero test coverage for refund, expireOverdue, and team-split paths

## How to test
- Run `npx jest --testPathPatterns="bounties.service.spec|github-webhooks.service.spec"` — all 22 tests pass
- Verify `auth.module.ts` no longer uses `as unknown as`