### PR TITLE
fix: validate bounty deadline is strictly in the future (#108)

### DIFF
--- a/src/bounties/dto/create-bounty.dto.ts
+++ b/src/bounties/dto/create-bounty.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsOptional, IsUUID, IsISO8601 } from 'class-validator';
 import { AssetType, BountyDifficulty } from '../../common/enums';
+import { IsFutureDate } from '../../common/validators/date.validator';
 import {
   IsMoneyAmount,
   IsSupportedEscrowAsset,
@@ -35,5 +36,6 @@ export class CreateBountyDto {
   @ApiProperty({ required: false })
   @IsOptional()
   @IsISO8601()
+  @IsFutureDate()
   deadline?: string;
 }

--- a/src/common/validators/date.validator.ts
+++ b/src/common/validators/date.validator.ts
@@ -1,0 +1,26 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+export function IsFutureDate(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isFutureDate',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          if (typeof value !== 'string') return false;
+          const date = new Date(value);
+          return !isNaN(date.getTime()) && date.getTime() > Date.now();
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a date strictly in the future`;
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
Fixes #108

## What changed
- Added `IsFutureDate` custom validator in `src/common/validators/date.validator.ts`
- Applied `@IsFutureDate()` decorator to `deadline` field in `CreateBountyDto`
- Rejects ISO-8601 timestamps that are in the past or present at creation time

## Why
- Bounties with past deadlines become eligible for auto-expiry before they can be funded or claimed
- This produced bounties that were dead on arrival with no validation error

## How to test
- Create a bounty with a deadline in the past — should return 400 with validation error
- Create a bounty with a deadline in the future — should succeed
- Create a bounty without a deadline — should succeed (field is optional)