### PR TITLE
fix: restore eslint no-floating-promises and no-unsafe-argument to error (#109)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,8 +27,8 @@ export default tseslint.config(
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
       "prettier/prettier": ["error", { endOfLine: "auto" }],
     },
   },


### PR DESCRIPTION
Fixes #109

## What changed
- Restored `@typescript-eslint/no-floating-promises` from `'warn'` to `'error'`
- Restored `@typescript-eslint/no-unsafe-argument` from `'warn'` to `'error'`

## Why
- Both rules were downgraded to warn, allowing un-awaited promises to pass CI silently
- In a codebase handling financial transactions, a missed `await` on a payment write is exactly the bug this rule catches
- With warn severity, floating promises on escrow writes would never fail the build

## How to test
- Run `npm run lint` and verify the rules are now error-level
- Any existing floating promises in the codebase would now fail lint