### PR TITLE
refactor: remove unused computeSplitShares dead code (#111)

### DIFF
--- a/src/teams/team-split.util.spec.ts
+++ b/src/teams/team-split.util.spec.ts
@@ -1,8 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import {
-  computeSplitShares,
-  validateSplitPercentages,
-} from './team-split.util';
+import { validateSplitPercentages } from './team-split.util';
 
 describe('team split percentage math', () => {
   it('accepts splits that sum to exactly 100', () => {
@@ -45,24 +42,5 @@ describe('team split percentage math', () => {
 
   it('rejects an empty split list', () => {
     expect(() => validateSplitPercentages([])).toThrow(BadRequestException);
-  });
-
-  it('computeSplitShares divides an amount proportionally', () => {
-    const shares = computeSplitShares(1000, [
-      { percentage: 40 },
-      { percentage: 40 },
-      { percentage: 20 },
-    ]);
-    expect(shares).toEqual([400, 400, 200]);
-  });
-
-  it('computeSplitShares handles uneven thirds without losing precision beyond 7dp', () => {
-    const shares = computeSplitShares(100, [
-      { percentage: 33.33 },
-      { percentage: 33.33 },
-      { percentage: 33.34 },
-    ]);
-    const total = shares.reduce((a, b) => a + b, 0);
-    expect(total).toBeCloseTo(100, 5);
   });
 });

--- a/src/teams/team-split.util.ts
+++ b/src/teams/team-split.util.ts
@@ -21,14 +21,3 @@ export function validateSplitPercentages(splits: SplitLike[]): void {
     );
   }
 }
-
-/** Computes each member's absolute payout share for a given total bounty amount. */
-export function computeSplitShares(
-  totalAmount: number,
-  splits: SplitLike[],
-): number[] {
-  validateSplitPercentages(splits);
-  return splits.map(
-    (s) => Math.round(((totalAmount * s.percentage) / 100) * 1e7) / 1e7,
-  );
-}


### PR DESCRIPTION
Fixes #111

## What changed
- Removed `computeSplitShares` function from `team-split.util.ts`
- Removed its tests from `team-split.util.spec.ts`
- Only `validateSplitPercentages` remains exported from the util

## Why
- `computeSplitShares` was never imported outside its own spec file
- The actual production split math lives in `split-math.util.ts` using integer basis points
- Having two differently-precise split functions is a maintenance hazard

## How to test
- Run `npm test` to verify remaining tests pass
- Confirm no other file imports `computeSplitShares`