### PR TITLE
fix: gate Swagger in production, stop deposit clobbering monthlyDeposit, raise stale idempotency window

### DIFF
--- a/src/common/idempotency/idempotency.interceptor.spec.ts
+++ b/src/common/idempotency/idempotency.interceptor.spec.ts
@@ -10,10 +10,12 @@ import { firstValueFrom, lastValueFrom, of, throwError } from 'rxjs';
 import { IdempotencyKey } from '../entities/idempotency-key.entity';
 import { IdempotencyKeyStatus } from '../enums';
 import { IDEMPOTENCY_SCOPE_KEY } from './idempotent.decorator';
-import { IdempotencyInterceptor } from './idempotency.interceptor';
+import {
+  IdempotencyInterceptor,
+  STALE_PROCESSING_MS,
+} from './idempotency.interceptor';
 
 const PG_UNIQUE_VIOLATION = '23505';
-const STALE_PROCESSING_MS = 30 * 1000;
 
 function uniqueViolationError(): Error & { driverError: { code: string } } {
   return Object.assign(

--- a/src/common/idempotency/idempotency.interceptor.ts
+++ b/src/common/idempotency/idempotency.interceptor.ts
@@ -37,8 +37,17 @@ export const IDEMPOTENCY_KEY_TTL_MS = 24 * 60 * 60 * 1000;
  * A PROCESSING row older than this is treated as abandoned (the process
  * handling it almost certainly crashed rather than being merely slow) and
  * is reclaimed by the next request instead of permanently 409-ing.
+ *
+ * Must comfortably outlast the slowest legitimate handler: the escrow
+ * mutations this interceptor guards go through
+ * SorobanClientService.invoke → pollTransaction, which polls up to 10
+ * times at 2000ms (~20s) *on top of* the getAccount/simulate/send RPC
+ * round-trips. A 30s window was shorter than that worst case, letting a
+ * client retry reclaim a row whose original request was still actively
+ * running and re-execute a concurrent money-moving operation (#90). 90s
+ * leaves ~4x headroom over the poll ceiling for RPC latency.
  */
-const STALE_PROCESSING_MS = 30 * 1000;
+export const STALE_PROCESSING_MS = 90 * 1000;
 
 /** Postgres SQLSTATE for unique_violation. */
 const PG_UNIQUE_VIOLATION = '23505';

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,20 +53,29 @@ async function bootstrap() {
   );
   app.useGlobalFilters(new GlobalExceptionFilter());
 
-  const swaggerConfig = new DocumentBuilder()
-    .setTitle('MergeFi API')
-    .setDescription(
-      'Where Open Source Meets Finance — GitHub bounty escrow orchestration on Stellar/Soroban.',
-    )
-    .setVersion('0.1.0')
-    .addBearerAuth()
-    .build();
-  const document = SwaggerModule.createDocument(app, swaggerConfig);
-  SwaggerModule.setup('api/docs', app, document);
+  // The generated OpenAPI document hands anyone a complete, browsable map of
+  // the API (routes, DTO shapes, validation constraints), so it is never
+  // exposed in production — same spirit as the JWT-secret guard above.
+  if (env !== 'production') {
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('MergeFi API')
+      .setDescription(
+        'Where Open Source Meets Finance — GitHub bounty escrow orchestration on Stellar/Soroban.',
+      )
+      .setVersion('0.1.0')
+      .addBearerAuth()
+      .build();
+    const document = SwaggerModule.createDocument(app, swaggerConfig);
+    SwaggerModule.setup('api/docs', app, document);
+  }
 
   const port = configService.get('port', { infer: true });
   await app.listen(port);
 
-  console.log(`MergeFi backend listening on port ${port} — docs at /api/docs`);
+  console.log(
+    env === 'production'
+      ? `MergeFi backend listening on port ${port}`
+      : `MergeFi backend listening on port ${port} — docs at /api/docs`,
+  );
 }
 void bootstrap();

--- a/src/maintenance-pool/dto/create-pool.dto.ts
+++ b/src/maintenance-pool/dto/create-pool.dto.ts
@@ -1,7 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { AssetType } from '../../common/enums';
-import { IsSupportedEscrowAsset } from '../../common/validators/money.validator';
+import {
+  IsMoneyAmount,
+  IsSupportedEscrowAsset,
+} from '../../common/validators/money.validator';
 
 export class CreatePoolDto {
   @ApiProperty()
@@ -17,6 +20,12 @@ export class CreatePoolDto {
   @IsOptional()
   @IsUUID()
   createdById?: string;
+
+  /** The sponsor's standing recurring commitment; deposits never overwrite it (#93). */
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsMoneyAmount()
+  monthlyDeposit?: string;
 
   @ApiProperty({ enum: AssetType, default: AssetType.USDC })
   @IsSupportedEscrowAsset()

--- a/src/maintenance-pool/maintenance-pool.service.spec.ts
+++ b/src/maintenance-pool/maintenance-pool.service.spec.ts
@@ -104,6 +104,7 @@ describe('MaintenancePoolService', () => {
         id: 'pool-1',
         status: MaintenancePoolStatus.ACTIVE,
         balance: '0',
+        monthlyDeposit: '500',
         asset: AssetType.USDC,
         escrowId: null,
       });
@@ -124,7 +125,28 @@ describe('MaintenancePoolService', () => {
       );
       expect(pool.escrowId).toBe('escrow-1');
       expect(pool.balance).toBe('100.0000000');
-      expect(pool.monthlyDeposit).toBe('100');
+    });
+
+    // #93: monthlyDeposit records the sponsor's standing recurring
+    // commitment (set at pool creation), so an ad-hoc deposit must never
+    // overwrite it with the latest single deposit amount.
+    it('leaves monthlyDeposit untouched by ad-hoc deposits (#93)', async () => {
+      poolRepo.findOne.mockResolvedValue({
+        id: 'pool-1',
+        status: MaintenancePoolStatus.ACTIVE,
+        balance: '100',
+        monthlyDeposit: '500',
+        asset: AssetType.USDC,
+        escrowId: 'escrow-1',
+      });
+      escrowService.fund.mockResolvedValue({
+        id: 'escrow-2',
+        status: 'locked',
+      });
+
+      const pool = await service.deposit('pool-1', '50', 'GFUNDER');
+
+      expect(pool.monthlyDeposit).toBe('500');
     });
 
     it('accumulates balance across deposits', async () => {

--- a/src/maintenance-pool/maintenance-pool.service.ts
+++ b/src/maintenance-pool/maintenance-pool.service.ts
@@ -29,6 +29,7 @@ export class MaintenancePoolService {
       name: dto.name,
       repositoryId: dto.repositoryId ?? null,
       createdById: dto.createdById ?? null,
+      monthlyDeposit: dto.monthlyDeposit,
       asset: dto.asset,
       status: MaintenancePoolStatus.ACTIVE,
     });
@@ -72,7 +73,9 @@ export class MaintenancePoolService {
     }
 
     pool.balance = (Number(pool.balance) + Number(amount)).toFixed(7);
-    pool.monthlyDeposit = amount;
+    // monthlyDeposit is deliberately left untouched here: it records the
+    // sponsor's standing recurring commitment (set at pool creation), not
+    // "whatever the last deposit happened to be" (#93).
     return this.poolRepo.save(pool);
   }
 


### PR DESCRIPTION
## Summary

- Swagger/OpenAPI docs are no longer mounted when \`NODE_ENV=production\`; the \`api/docs\` UI previously exposed the full API surface (routes, DTO shapes, validation constraints) to unauthenticated visitors.
- \`MaintenancePoolService.deposit\` no longer overwrites \`monthlyDeposit\` with the latest single deposit amount; the field now records the sponsor's standing recurring commitment and can be set at pool creation via an optional, validated DTO field.
- \`IdempotencyInterceptor\`'s stale-processing reclaim window is raised from 30s to 90s so it comfortably outlasts the Soroban client's worst-case duration (~20s polling ceiling plus RPC round-trips), preventing a retry from reclaiming a row whose original money-moving request was still actively running.

## Changes

- \`src/main.ts\`: gate \`SwaggerModule.createDocument\`/\`SwaggerModule.setup\` behind \`env !== 'production'\`, consistent with the existing JWT-secret production guard; startup log only advertises \`/api/docs\` outside production.
- \`src/maintenance-pool/maintenance-pool.service.ts\`: removed \`pool.monthlyDeposit = amount\` from \`deposit()\`; \`create()\` now passes the optional \`monthlyDeposit\` through.
- \`src/maintenance-pool/dto/create-pool.dto.ts\`: added optional \`monthlyDeposit\` validated with the existing \`@IsMoneyAmount()\`.
- \`src/common/idempotency/idempotency.interceptor.ts\`: \`STALE_PROCESSING_MS\` 30s → 90s, exported with a doc comment deriving the value from \`SorobanClientService.pollTransaction\`'s worst case.
- Updated specs: idempotency interceptor spec imports the shared constant instead of duplicating it; maintenance pool spec asserts deposits leave \`monthlyDeposit\` untouched.

## Issues

Resolves #99
Resolves #93
Resolves #90
Resolves #102

## Verification

Manual code review only: full diff inspected against each issue's report, entity/DTO/config/spec conventions checked, no unrelated changes. \`cargo build\` and \`cargo test\` were not run (Node/NestJS project); test suite and build were not executed.