### PR TITLE
fix(github-sync): read rate-limit headers from existing responses ins…

### DIFF
--- a/src/github/github-sync.service.spec.ts
+++ b/src/github/github-sync.service.spec.ts
@@ -9,6 +9,12 @@ import {
 } from './github-sync.service';
 import { GITHUB_OCTOKIT } from './octokit.provider';
 
+const RATE_LIMIT_HEADERS = {
+  'x-ratelimit-limit': '5000',
+  'x-ratelimit-remaining': '4999',
+  'x-ratelimit-reset': '1234567890',
+};
+
 function issuePage(items: Array<Partial<RawGithubIssue>>) {
   return {
     data: items.map((item) => ({
@@ -20,6 +26,7 @@ function issuePage(items: Array<Partial<RawGithubIssue>>) {
       updated_at: '2026-01-01T00:00:00Z',
       ...item,
     })),
+    headers: RATE_LIMIT_HEADERS,
   };
 }
 
@@ -45,7 +52,6 @@ describe('GithubSyncService', () => {
     pulls: { get: jest.Mock };
     issues: { listForRepo: jest.Mock };
     paginate: { iterator: jest.Mock };
-    rest: { rateLimit: { get: jest.Mock } };
   };
   let repositoryRepo: {
     findOne: jest.Mock;
@@ -69,7 +75,6 @@ describe('GithubSyncService', () => {
       pulls: { get: jest.fn() },
       issues: { listForRepo: jest.fn() },
       paginate: { iterator: jest.fn() },
-      rest: { rateLimit: { get: jest.fn() } },
     };
     repositoryRepo = {
       findOne: jest.fn().mockResolvedValue(null),
@@ -99,14 +104,6 @@ describe('GithubSyncService', () => {
     logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
-
-    octokit.rest.rateLimit.get.mockResolvedValue({
-      data: {
-        resources: {
-          core: { limit: 5000, remaining: 4999, reset: 1234567890 },
-        },
-      },
-    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -321,8 +318,8 @@ describe('GithubSyncService', () => {
     });
   });
 
-  describe('syncRepository — rate-limit budget logging (#24)', () => {
-    it('logs rate-limit status before and after a sync', async () => {
+  describe('syncRepository — rate-limit budget logging (#24, #62)', () => {
+    it('logs rate-limit status from response headers before and after a sync', async () => {
       octokit.repos.get.mockResolvedValue({
         data: {
           id: 42,
@@ -332,6 +329,7 @@ describe('GithubSyncService', () => {
           default_branch: 'main',
           private: false,
         },
+        headers: RATE_LIMIT_HEADERS,
       });
       octokit.paginate.iterator.mockReturnValue(
         pagesThenThrow([issuePage([])]),
@@ -344,11 +342,9 @@ describe('GithubSyncService', () => {
         .filter((msg) => msg.includes('rate-limit'));
       expect(rateLimitLogs.some((m) => m.includes('before'))).toBe(true);
       expect(rateLimitLogs.some((m) => m.includes('after'))).toBe(true);
-      expect(octokit.rest.rateLimit.get).toHaveBeenCalledTimes(2);
     });
 
-    it('does not let a rate-limit status lookup failure block the sync itself', async () => {
-      octokit.rest.rateLimit.get.mockRejectedValue(new Error('unreachable'));
+    it('still syncs successfully when response headers lack rate-limit fields', async () => {
       octokit.repos.get.mockResolvedValue({
         data: {
           id: 42,
@@ -358,6 +354,7 @@ describe('GithubSyncService', () => {
           default_branch: 'main',
           private: false,
         },
+        headers: {},
       });
       octokit.paginate.iterator.mockReturnValue(
         pagesThenThrow([issuePage([])]),

--- a/src/github/github-sync.service.ts
+++ b/src/github/github-sync.service.ts
@@ -80,9 +80,10 @@ export class GithubSyncService {
 
   /** Imports (or refreshes) a single repository and all of its open+closed issues. */
   async syncRepository(owner: string, repo: string): Promise<Repository> {
-    await this.logRateLimitStatus(`before ${owner}/${repo}`);
+    const repoResponse = await this.octokit.repos.get({ owner, repo });
+    this.logRateLimitFromHeaders(`before ${owner}/${repo}`, repoResponse.headers);
 
-    const { data: repoData } = await this.octokit.repos.get({ owner, repo });
+    const { data: repoData } = repoResponse;
 
     let repository = await this.repositoryRepo.findOne({
       where: { githubRepoId: String(repoData.id) },
@@ -106,11 +107,7 @@ export class GithubSyncService {
       : this.repositoryRepo.create(attrs);
     repository = await this.repositoryRepo.save(repository);
 
-    try {
-      await this.syncIssues(repository, owner, repo);
-    } finally {
-      await this.logRateLimitStatus(`after ${owner}/${repo}`);
-    }
+    await this.syncIssues(repository, owner, repo);
     return repository;
   }
 
@@ -145,6 +142,10 @@ export class GithubSyncService {
           );
           if (applied) saved.push(issue);
         }
+        this.logRateLimitFromHeaders(
+          `after ${owner}/${repo} (page ${pagesFetched})`,
+          response.headers,
+        );
       }
     } catch (err) {
       const cause = err as Error;
@@ -249,22 +250,23 @@ export class GithubSyncService {
   }
 
   /**
-   * Logs remaining/limit for the core REST rate-limit budget around large
-   * sync operations (#24), so a mid-sync rate-limit interruption shows up as
-   * an obviously-low "before" number in logs rather than a mystery failure.
-   * Best-effort: a failure to fetch rate-limit status never blocks the sync.
+   * Logs remaining/limit for the core REST rate-limit budget from the
+   * response headers of an already-made API call (#24, #62). Reads the
+   * x-ratelimit-* headers that GitHub includes on every REST response
+   * instead of issuing a dedicated rateLimit.get() request, which would
+   * itself consume quota and accelerate the very exhaustion being monitored.
    */
-  private async logRateLimitStatus(label: string): Promise<void> {
-    try {
-      const { data } = await this.octokit.rest.rateLimit.get();
-      const { limit, remaining, reset } = data.resources.core;
+  private logRateLimitFromHeaders(
+    label: string,
+    headers: Record<string, unknown>,
+  ): void {
+    const remaining = headers['x-ratelimit-remaining'];
+    const limit = headers['x-ratelimit-limit'];
+    const reset = headers['x-ratelimit-reset'];
+    if (remaining != null && limit != null && reset != null) {
       this.logger.log(
         `[rate-limit ${label}] core: ${remaining}/${limit} remaining, ` +
-          `resets at ${new Date(reset * 1000).toISOString()}`,
-      );
-    } catch (err) {
-      this.logger.warn(
-        `Failed to fetch rate-limit status (${label}): ${(err as Error).message}`,
+          `resets at ${new Date(Number(reset) * 1000).toISOString()}`,
       );
     }
   }


### PR DESCRIPTION
…tead of dedicated API calls

logRateLimitStatus() issued a dedicated rateLimit.get() request before and after every syncRepository call — each consuming primary rate-limit quota. This accelerated the very exhaustion the logging was meant to diagnose, especially when the unauthenticated sync endpoint is hit repeatedly (#62).

Replace it with logRateLimitFromHeaders(), which reads x-ratelimit-remaining, x-ratelimit-limit, and x-ratelimit-reset from the responses already being made (repos.get and paginated issues.listForRepo). This eliminates 2 extra API requests per sync while preserving the same observability output.

Done. Branch `fix/remove-dedicated-rate-limit-api-calls` is ready with commit `a6ec842`.

**Summary of changes:**

- **`src/github/github-sync.service.ts`** — Replaced `logRateLimitStatus()` (which called `octokit.rest.rateLimit.get()`, consuming 2 API requests per sync) with `logRateLimitFromHeaders()`, a synchronous method that reads `x-ratelimit-remaining/limit/reset` from the response headers of the `repos.get` and paginated `issues.listForRepo` calls already being made. The "before" log now comes from the `repos.get` response, and the "after" log comes from each page of the issues iterator. Zero extra API requests.

- **`src/github/github-sync.service.spec.ts`** — Updated mocks to include rate-limit headers on responses, removed the `rest.rateLimit.get` mock, and replaced the "rate-limit failure doesn't block sync" test with a "missing headers don't block sync" test. All 10 tests pass.

Closes #128
Closes #122
Closes #123
Closes #126