### PR TITLE
fix: enforce maintenance rewards, roles, and issue constraints

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,16 +2,20 @@ import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '../users/users.module';
+import { User } from '../common/entities';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { GithubStrategy } from './strategies/github.strategy';
 import { AppConfig } from '../config/configuration';
+import { RolesGuard } from './guards/roles.guard';
 
 @Module({
   imports: [
     UsersModule,
+    TypeOrmModule.forFeature([User]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       inject: [ConfigService],
@@ -25,7 +29,7 @@ import { AppConfig } from '../config/configuration';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, GithubStrategy],
-  exports: [AuthService],
+  providers: [AuthService, JwtStrategy, GithubStrategy, RolesGuard],
+  exports: [AuthService, RolesGuard],
 })
 export class AuthModule {}

--- a/src/auth/decorators/roles.decorator.ts
+++ b/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '../../common/enums';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/guards/roles.guard.spec.ts
+++ b/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,59 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { User } from '../../common/entities';
+import { UserRole } from '../../common/enums';
+import { RolesGuard } from './roles.guard';
+
+describe('RolesGuard', () => {
+  const reflector = { getAllAndOverride: jest.fn() };
+  const userRepo = { findOne: jest.fn() };
+  const context = (user?: { userId: string }) =>
+    ({
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    }) as never;
+
+  let guard: RolesGuard;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    guard = await Test.createTestingModule({
+      providers: [
+        RolesGuard,
+        { provide: Reflector, useValue: reflector },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+      ],
+    })
+      .compile()
+      .then((module) => module.get(RolesGuard));
+  });
+
+  it('allows an authenticated user with a required role', async () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.MAINTAINER]);
+    userRepo.findOne.mockResolvedValue({ roles: [UserRole.MAINTAINER] });
+
+    await expect(
+      guard.canActivate(context({ userId: 'user-1' })),
+    ).resolves.toBe(true);
+  });
+
+  it('denies an authenticated user without a required role', async () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.SPONSOR]);
+    userRepo.findOne.mockResolvedValue({ roles: [UserRole.CONTRIBUTOR] });
+
+    await expect(
+      guard.canActivate(context({ userId: 'user-1' })),
+    ).resolves.toBe(false);
+  });
+
+  it('rejects requests that did not pass JWT authentication', async () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.SPONSOR]);
+
+    await expect(guard.canActivate(context())).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,48 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Request } from 'express';
+import { Repository } from 'typeorm';
+import { User } from '../../common/entities';
+import { UserRole } from '../../common/enums';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+interface AuthenticatedRequest extends Request {
+  user?: { userId: string };
+}
+
+/** Requires at least one role declared by @Roles, reading current roles from the database. */
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    @InjectRepository(User) private readonly userRepo: Repository<User>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!requiredRoles?.length) return true;
+
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    if (!request.user?.userId) {
+      throw new UnauthorizedException('Authentication is required');
+    }
+
+    const user = await this.userRepo.findOne({
+      where: { id: request.user.userId },
+      select: { id: true, roles: true },
+    });
+    if (!user)
+      throw new UnauthorizedException('Authenticated user no longer exists');
+
+    return requiredRoles.some((role) => user.roles.includes(role));
+  }
+}

--- a/src/bounties/bounties.controller.ts
+++ b/src/bounties/bounties.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Get, Param, ParseEnumPipe, ParseUUIDPipe, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseEnumPipe,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { BountiesService } from './bounties.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
@@ -6,6 +16,10 @@ import { ClaimBountyDto } from './dto/claim-bounty.dto';
 import { BountyStatus } from '../common/enums';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
 import { IsStellarAddress } from '../common/validators/stellar-address.validator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../common/enums';
 
 class FundBountyDto {
   @IsStellarAddress()
@@ -18,13 +32,18 @@ export class BountiesController {
   constructor(private readonly bountiesService: BountiesService) {}
 
   @Idempotent('bounty.create')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SPONSOR, UserRole.MAINTAINER)
   @Post()
   create(@Body() dto: CreateBountyDto) {
     return this.bountiesService.create(dto);
   }
 
   @Get()
-  list(@Query('status', new ParseEnumPipe(BountyStatus, { optional: true })) status?: BountyStatus) {
+  list(
+    @Query('status', new ParseEnumPipe(BountyStatus, { optional: true }))
+    status?: BountyStatus,
+  ) {
     return this.bountiesService.list(status);
   }
 
@@ -34,18 +53,30 @@ export class BountiesController {
   }
 
   @Idempotent('bounty.fund')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SPONSOR, UserRole.MAINTAINER)
   @Post(':id/fund')
-  fund(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: FundBountyDto) {
+  fund(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: FundBountyDto,
+  ) {
     return this.bountiesService.fund(id, dto.funderAddress);
   }
 
   @Idempotent('bounty.claim')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.CONTRIBUTOR)
   @Post(':id/claim')
-  claim(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: ClaimBountyDto) {
+  claim(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: ClaimBountyDto,
+  ) {
     return this.bountiesService.claim(id, dto.contributorId);
   }
 
   @Idempotent('bounty.refund')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SPONSOR, UserRole.MAINTAINER)
   @Post(':id/refund')
   refund(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.bountiesService.refund(id);

--- a/src/bounties/bounties.module.ts
+++ b/src/bounties/bounties.module.ts
@@ -4,9 +4,14 @@ import { Bounty, Team, User } from '../common/entities';
 import { BountiesService } from './bounties.service';
 import { BountiesController } from './bounties.controller';
 import { EscrowModule } from '../escrow/escrow.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Bounty, Team, User]), EscrowModule],
+  imports: [
+    TypeOrmModule.forFeature([Bounty, Team, User]),
+    EscrowModule,
+    AuthModule,
+  ],
   controllers: [BountiesController],
   providers: [BountiesService],
   exports: [BountiesService],

--- a/src/common/entities/bounty.entity.ts
+++ b/src/common/entities/bounty.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   OneToOne,
@@ -38,6 +39,7 @@ export class Bounty {
   claimedBy: User | null;
 
   @Column({ type: 'varchar', nullable: true })
+  @Index('IDX_bounties_claimedById')
   claimedById: string | null;
 
   /** Set when the bounty payout is split across a team instead of one contributor. */

--- a/src/common/entities/issue.entity.ts
+++ b/src/common/entities/issue.entity.ts
@@ -12,6 +12,7 @@ import {
 import { Repository } from './repository.entity';
 import { Milestone } from './milestone.entity';
 import { Bounty } from './bounty.entity';
+import { IssueState } from '../enums';
 
 @Entity('issues')
 @Index(['repositoryId', 'number'], { unique: true })
@@ -38,8 +39,8 @@ export class Issue {
   @Column({ type: 'text', nullable: true })
   body: string | null;
 
-  @Column({ default: 'open' })
-  state: 'open' | 'closed';
+  @Column({ type: 'enum', enum: IssueState, default: IssueState.OPEN })
+  state: IssueState;
 
   @Column({ type: 'simple-array', default: '' })
   labels: string[];

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -4,6 +4,11 @@ export enum UserRole {
   SPONSOR = 'sponsor',
 }
 
+export enum IssueState {
+  OPEN = 'open',
+  CLOSED = 'closed',
+}
+
 /**
  * Lifecycle of a paid issue (bounty).
  *

--- a/src/database/migrations/1784700000000-AddIssueStateEnumAndBountyClaimedByIndex.ts
+++ b/src/database/migrations/1784700000000-AddIssueStateEnumAndBountyClaimedByIndex.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** Enforces the Issue lifecycle at the database boundary and indexes contributor lookups. */
+export class AddIssueStateEnumAndBountyClaimedByIndex1784700000000 implements MigrationInterface {
+  name = 'AddIssueStateEnumAndBountyClaimedByIndex1784700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "issues_state_enum" AS ENUM ('open', 'closed')`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "issues"
+      ALTER COLUMN "state" DROP DEFAULT,
+      ALTER COLUMN "state" TYPE "issues_state_enum"
+      USING "state"::"issues_state_enum",
+      ALTER COLUMN "state" SET DEFAULT 'open'
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_bounties_claimedById" ON "bounties" ("claimedById")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_bounties_claimedById"`);
+    await queryRunner.query(`
+      ALTER TABLE "issues"
+      ALTER COLUMN "state" DROP DEFAULT,
+      ALTER COLUMN "state" TYPE varchar
+      USING "state"::text,
+      ALTER COLUMN "state" SET DEFAULT 'open'
+    `);
+    await queryRunner.query(`DROP TYPE "issues_state_enum"`);
+  }
+}

--- a/src/github/github-sync.service.ts
+++ b/src/github/github-sync.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Octokit } from '@octokit/rest';
 import { Repository as TypeOrmRepository } from 'typeorm';
 import { Issue, Repository } from '../common/entities';
+import { IssueState } from '../common/enums';
 import { GITHUB_OCTOKIT } from './octokit.provider';
 
 const MAINTENANCE_LABELS = ['maintenance', 'dependencies', 'chore', 'docs'];
@@ -81,7 +82,10 @@ export class GithubSyncService {
   /** Imports (or refreshes) a single repository and all of its open+closed issues. */
   async syncRepository(owner: string, repo: string): Promise<Repository> {
     const repoResponse = await this.octokit.repos.get({ owner, repo });
-    this.logRateLimitFromHeaders(`before ${owner}/${repo}`, repoResponse.headers);
+    this.logRateLimitFromHeaders(
+      `before ${owner}/${repo}`,
+      repoResponse.headers,
+    );
 
     const { data: repoData } = repoResponse;
 
@@ -202,7 +206,7 @@ export class GithubSyncService {
       number: raw.number,
       title: raw.title,
       body: raw.body ?? null,
-      state: raw.state as 'open' | 'closed',
+      state: raw.state as IssueState,
       labels,
       githubUrl: raw.html_url,
       authorLogin: raw.user?.login ?? null,

--- a/src/maintenance-pool/maintenance-pool.controller.ts
+++ b/src/maintenance-pool/maintenance-pool.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { IsOptional, IsUUID } from 'class-validator';
 import { MaintenancePoolService } from './maintenance-pool.service';
@@ -6,6 +14,10 @@ import { CreatePoolDto } from './dto/create-pool.dto';
 import { IsMoneyAmount } from '../common/validators/money.validator';
 import { IsStellarAddress } from '../common/validators/stellar-address.validator';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../common/enums';
 
 class DepositDto {
   @IsMoneyAmount()
@@ -16,6 +28,9 @@ class DepositDto {
 }
 
 class AssignRewardDto {
+  @IsUUID()
+  issueId: string;
+
   @IsMoneyAmount()
   amount: string;
 
@@ -33,6 +48,8 @@ export class MaintenancePoolController {
   constructor(private readonly poolService: MaintenancePoolService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SPONSOR, UserRole.MAINTAINER)
   create(@Body() dto: CreatePoolDto) {
     return this.poolService.create(dto);
   }
@@ -48,16 +65,27 @@ export class MaintenancePoolController {
   }
 
   @Idempotent('pool.deposit')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SPONSOR, UserRole.MAINTAINER)
   @Post(':id/deposit')
-  deposit(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: DepositDto) {
+  deposit(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: DepositDto,
+  ) {
     return this.poolService.deposit(id, dto.amount, dto.funderAddress);
   }
 
   @Idempotent('pool.assignReward')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.MAINTAINER)
   @Post(':id/assign-reward')
-  assignReward(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: AssignRewardDto) {
+  assignReward(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: AssignRewardDto,
+  ) {
     return this.poolService.assignReward(
       id,
+      dto.issueId,
       dto.amount,
       dto.recipientAddress,
       dto.recipientId,

--- a/src/maintenance-pool/maintenance-pool.module.ts
+++ b/src/maintenance-pool/maintenance-pool.module.ts
@@ -1,12 +1,17 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { MaintenancePool } from '../common/entities';
+import { Issue, MaintenancePool } from '../common/entities';
 import { MaintenancePoolService } from './maintenance-pool.service';
 import { MaintenancePoolController } from './maintenance-pool.controller';
 import { EscrowModule } from '../escrow/escrow.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MaintenancePool]), EscrowModule],
+  imports: [
+    TypeOrmModule.forFeature([MaintenancePool, Issue]),
+    EscrowModule,
+    AuthModule,
+  ],
   controllers: [MaintenancePoolController],
   providers: [MaintenancePoolService],
   exports: [MaintenancePoolService],

--- a/src/maintenance-pool/maintenance-pool.service.spec.ts
+++ b/src/maintenance-pool/maintenance-pool.service.spec.ts
@@ -3,7 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { MaintenancePoolService } from './maintenance-pool.service';
 import { EscrowService } from '../escrow/escrow.service';
-import { MaintenancePool } from '../common/entities';
+import { Issue, MaintenancePool } from '../common/entities';
 import { AssetType, MaintenancePoolStatus } from '../common/enums';
 
 describe('MaintenancePoolService', () => {
@@ -15,6 +15,7 @@ describe('MaintenancePoolService', () => {
     find: jest.Mock;
   };
   let escrowService: { fund: jest.Mock; releasePartial: jest.Mock };
+  let issueRepo: { findOne: jest.Mock };
 
   beforeEach(async () => {
     poolRepo = {
@@ -29,11 +30,19 @@ describe('MaintenancePoolService', () => {
       fund: jest.fn(),
       releasePartial: jest.fn(),
     };
+    issueRepo = {
+      findOne: jest.fn().mockResolvedValue({
+        id: 'issue-1',
+        isMaintenanceType: true,
+        repositoryId: 'repository-1',
+      }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MaintenancePoolService,
         { provide: getRepositoryToken(MaintenancePool), useValue: poolRepo },
+        { provide: getRepositoryToken(Issue), useValue: issueRepo },
         { provide: EscrowService, useValue: escrowService },
       ],
     }).compile();
@@ -215,7 +224,7 @@ describe('MaintenancePoolService', () => {
       });
 
       await expect(
-        service.assignReward('pool-1', '10', 'GRECIPIENT'),
+        service.assignReward('pool-1', 'issue-1', '10', 'GRECIPIENT'),
       ).rejects.toThrow(BadRequestException);
       expect(escrowService.releasePartial).not.toHaveBeenCalled();
     });
@@ -228,7 +237,7 @@ describe('MaintenancePoolService', () => {
       });
 
       await expect(
-        service.assignReward('pool-1', '100', 'GRECIPIENT'),
+        service.assignReward('pool-1', 'issue-1', '100', 'GRECIPIENT'),
       ).rejects.toThrow(BadRequestException);
       expect(escrowService.releasePartial).not.toHaveBeenCalled();
     });
@@ -243,6 +252,7 @@ describe('MaintenancePoolService', () => {
 
       const payment = await service.assignReward(
         'pool-1',
+        'issue-1',
         '30',
         'GRECIPIENT',
         'user-1',
@@ -258,6 +268,43 @@ describe('MaintenancePoolService', () => {
       expect(poolRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({ balance: '70.0000000' }),
       );
+    });
+
+    it('rejects a reward for a non-maintenance issue before releasing funds', async () => {
+      poolRepo.findOne.mockResolvedValue({
+        id: 'pool-1',
+        balance: '100',
+        escrowId: 'escrow-1',
+      });
+      issueRepo.findOne.mockResolvedValue({
+        id: 'issue-1',
+        isMaintenanceType: false,
+        repositoryId: 'repository-1',
+      });
+
+      await expect(
+        service.assignReward('pool-1', 'issue-1', '10', 'GRECIPIENT'),
+      ).rejects.toThrow(BadRequestException);
+      expect(escrowService.releasePartial).not.toHaveBeenCalled();
+    });
+
+    it('rejects an issue outside the pool repository', async () => {
+      poolRepo.findOne.mockResolvedValue({
+        id: 'pool-1',
+        repositoryId: 'repository-1',
+        balance: '100',
+        escrowId: 'escrow-1',
+      });
+      issueRepo.findOne.mockResolvedValue({
+        id: 'issue-1',
+        isMaintenanceType: true,
+        repositoryId: 'repository-2',
+      });
+
+      await expect(
+        service.assignReward('pool-1', 'issue-1', '10', 'GRECIPIENT'),
+      ).rejects.toThrow(BadRequestException);
+      expect(escrowService.releasePartial).not.toHaveBeenCalled();
     });
 
     // Regression baseline for #51 (MaintenancePool.balance is a
@@ -287,8 +334,8 @@ describe('MaintenancePoolService', () => {
       escrowService.releasePartial.mockResolvedValue({ id: 'payment-x' });
 
       await Promise.all([
-        service.assignReward('pool-1', '100', 'GRECIPIENT_A'),
-        service.assignReward('pool-1', '200', 'GRECIPIENT_B'),
+        service.assignReward('pool-1', 'issue-1', '100', 'GRECIPIENT_A'),
+        service.assignReward('pool-1', 'issue-1', '200', 'GRECIPIENT_B'),
       ]);
 
       // Both concurrent calls read balance=1000 before either wrote back,

--- a/src/maintenance-pool/maintenance-pool.service.ts
+++ b/src/maintenance-pool/maintenance-pool.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { MaintenancePool } from '../common/entities';
+import { Issue, MaintenancePool } from '../common/entities';
 import { MaintenancePoolStatus } from '../common/enums';
 import { EscrowService } from '../escrow/escrow.service';
 import { CreatePoolDto } from './dto/create-pool.dto';
@@ -21,6 +21,8 @@ export class MaintenancePoolService {
   constructor(
     @InjectRepository(MaintenancePool)
     private readonly poolRepo: Repository<MaintenancePool>,
+    @InjectRepository(Issue)
+    private readonly issueRepo: Repository<Issue>,
     private readonly escrowService: EscrowService,
   ) {}
 
@@ -82,11 +84,24 @@ export class MaintenancePoolService {
   /** Maintainer assigns a reward from the pool's balance for completed maintenance work. */
   async assignReward(
     id: string,
+    issueId: string,
     amount: string,
     recipientAddress: string,
     recipientId?: string,
   ) {
     const pool = await this.findOne(id);
+    const issue = await this.issueRepo.findOne({ where: { id: issueId } });
+    if (!issue) throw new NotFoundException(`Issue ${issueId} not found`);
+    if (!issue.isMaintenanceType) {
+      throw new BadRequestException(
+        `Issue ${issueId} is not eligible for maintenance-pool rewards`,
+      );
+    }
+    if (pool.repositoryId && pool.repositoryId !== issue.repositoryId) {
+      throw new BadRequestException(
+        `Issue ${issueId} does not belong to pool ${id}'s repository`,
+      );
+    }
     if (!pool.escrowId) {
       throw new BadRequestException(`Pool ${id} has no funded escrow yet`);
     }

--- a/src/milestones/milestones.controller.ts
+++ b/src/milestones/milestones.controller.ts
@@ -1,10 +1,22 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { IsOptional, IsUUID } from 'class-validator';
 import { MilestonesService } from './milestones.service';
 import { CreateMilestoneDto } from './dto/create-milestone.dto';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
 import { IsStellarAddress } from '../common/validators/stellar-address.validator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../common/enums';
 
 class FundMilestoneDto {
   @IsStellarAddress()
@@ -26,6 +38,8 @@ export class MilestonesController {
   constructor(private readonly milestonesService: MilestonesService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SPONSOR, UserRole.MAINTAINER)
   create(@Body() dto: CreateMilestoneDto) {
     return this.milestonesService.create(dto);
   }
@@ -41,17 +55,29 @@ export class MilestonesController {
   }
 
   @Idempotent('milestone.fund')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SPONSOR, UserRole.MAINTAINER)
   @Post(':id/fund')
-  fund(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: FundMilestoneDto) {
+  fund(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: FundMilestoneDto,
+  ) {
     return this.milestonesService.fund(id, dto.funderAddress);
   }
 
   @Post(':id/issues/:issueId')
-  addIssue(@Param('id', new ParseUUIDPipe()) id: string, @Param('issueId', new ParseUUIDPipe()) issueId: string) {
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.MAINTAINER)
+  addIssue(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Param('issueId', new ParseUUIDPipe()) issueId: string,
+  ) {
     return this.milestonesService.addIssue(id, issueId);
   }
 
   @Idempotent('milestone.resolveIssue')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.MAINTAINER)
   @Post(':id/issues/:issueId/resolve')
   resolveIssue(
     @Param('id', new ParseUUIDPipe()) id: string,

--- a/src/milestones/milestones.module.ts
+++ b/src/milestones/milestones.module.ts
@@ -4,9 +4,14 @@ import { Issue, Milestone } from '../common/entities';
 import { MilestonesService } from './milestones.service';
 import { MilestonesController } from './milestones.controller';
 import { EscrowModule } from '../escrow/escrow.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Milestone, Issue]), EscrowModule],
+  imports: [
+    TypeOrmModule.forFeature([Milestone, Issue]),
+    EscrowModule,
+    AuthModule,
+  ],
   controllers: [MilestonesController],
   providers: [MilestonesService],
   exports: [MilestonesService],

--- a/src/milestones/milestones.service.ts
+++ b/src/milestones/milestones.service.ts
@@ -6,7 +6,7 @@ import {
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { Issue, Milestone } from '../common/entities';
-import { MilestoneStatus } from '../common/enums';
+import { IssueState, MilestoneStatus } from '../common/enums';
 import { EscrowService } from '../escrow/escrow.service';
 import { CreateMilestoneDto } from './dto/create-milestone.dto';
 
@@ -145,9 +145,7 @@ export class MilestonesService {
         recipientId,
       );
 
-      const newDistributed = (
-        Number(milestone.distributed) + share
-      ).toFixed(7);
+      const newDistributed = (Number(milestone.distributed) + share).toFixed(7);
       const newStatus =
         Number(newDistributed) >= Number(milestone.budget) - 1e-7
           ? MilestoneStatus.COMPLETED
@@ -158,7 +156,7 @@ export class MilestonesService {
       });
 
       await mgr.update(Issue, issueId, {
-        state: 'closed',
+        state: IssueState.CLOSED,
         closedAt: new Date(),
       });
 

--- a/src/teams/teams.controller.ts
+++ b/src/teams/teams.controller.ts
@@ -1,7 +1,20 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { TeamsService } from './teams.service';
 import { CreateTeamDto, TeamMemberSplitDto } from './dto/create-team.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../common/enums';
 
 @ApiTags('teams')
 @Controller('teams')
@@ -9,6 +22,8 @@ export class TeamsController {
   constructor(private readonly teamsService: TeamsService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.MAINTAINER, UserRole.SPONSOR)
   create(@Body() dto: CreateTeamDto) {
     return this.teamsService.create(dto);
   }
@@ -19,6 +34,8 @@ export class TeamsController {
   }
 
   @Patch(':id/splits')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.MAINTAINER, UserRole.SPONSOR)
   updateSplits(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() members: TeamMemberSplitDto[],
@@ -27,7 +44,12 @@ export class TeamsController {
   }
 
   @Post(':id/assign/:bountyId')
-  assign(@Param('id', new ParseUUIDPipe()) id: string, @Param('bountyId', new ParseUUIDPipe()) bountyId: string) {
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.MAINTAINER, UserRole.SPONSOR)
+  assign(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Param('bountyId', new ParseUUIDPipe()) bountyId: string,
+  ) {
     return this.teamsService.assignToBounty(id, bountyId);
   }
 }

--- a/src/teams/teams.module.ts
+++ b/src/teams/teams.module.ts
@@ -3,9 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Bounty, Team, TeamMemberSplit } from '../common/entities';
 import { TeamsService } from './teams.service';
 import { TeamsController } from './teams.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Team, TeamMemberSplit, Bounty])],
+  imports: [
+    TypeOrmModule.forFeature([Team, TeamMemberSplit, Bounty]),
+    AuthModule,
+  ],
   controllers: [TeamsController],
   providers: [TeamsService],
   exports: [TeamsService],

--- a/test/stellar-address-validation-maintenance-pool.e2e-spec.ts
+++ b/test/stellar-address-validation-maintenance-pool.e2e-spec.ts
@@ -10,6 +10,8 @@ import { MaintenancePoolService } from '../src/maintenance-pool/maintenance-pool
 import { IdempotencyKeyStatus } from '../src/common/enums';
 import { IdempotencyKey } from '../src/common/entities/idempotency-key.entity';
 import { IdempotencyInterceptor } from '../src/common/idempotency/idempotency.interceptor';
+import { JwtAuthGuard } from '../src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../src/auth/guards/roles.guard';
 
 /** Same in-memory stand-in used across this directory's e2e specs — see
  * escrow-idempotency.e2e-spec.ts's FakeIdempotencyRepo for the rationale
@@ -101,7 +103,12 @@ describe('Stellar address validation at the API boundary — maintenance-pool en
           useValue: new FakeIdempotencyRepo(),
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(
@@ -111,7 +118,7 @@ describe('Stellar address validation at the API boundary — maintenance-pool en
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   beforeEach(() => {
@@ -170,6 +177,7 @@ describe('Stellar address validation at the API boundary — maintenance-pool en
       .post('/maintenance-pools/pool_1/assign-reward')
       .set('Idempotency-Key', randomUUID())
       .send({
+        issueId: randomUUID(),
         amount: '5.0000000',
         recipientAddress: Keypair.random().publicKey(),
       })


### PR DESCRIPTION
## Summary
- require a synced maintenance issue before releasing maintenance-pool rewards
- add role-based authorization for privileged bounty, milestone, pool, and team mutations
- enforce issue state with a Postgres enum and index bounty contributor lookups

## Validation
- 

Closes #148
Closes #146
Closes #145
Closes #147