### PR TITLE
Fix #153, #152, #163, #166: required-secret boot guard, overdue-bounty scheduler, maintenance-pool withdraw model, shared contributor-stats helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # ---------------------------------------------------------------------------
 # MergeFi Backend — Environment Configuration
 # Copy this file to `.env` and fill in real values for local development.
+#
+# When NODE_ENV=production the app refuses to start unless every one of
+# JWT_SECRET, DATABASE_URL, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET,
+# GITHUB_WEBHOOK_SECRET, ESCROW_CONTRACT_ID and TREASURY_SECRET is set to a
+# real (non-default, non-empty) value — see src/config/validate-required-config.ts.
 # ---------------------------------------------------------------------------
 
 # --- App ---------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -267,9 +267,15 @@ docker build --target runner -t mergefi-backend:latest .
 #### Production Guardrails (Important):
 - **Least Privilege**: The container runs under the non-root `node` user (`USER node`).
 - **Production Mode**: The final image forces `NODE_ENV=production`.
-- **JWT Secret Enforcer**: If the application boots in production with the default `JWT_SECRET=insecure-dev-secret` (or is missing entirely), the startup hook in `src/main.ts` will crash the container. You **must** provide a secure custom `JWT_SECRET` when running the production container:
+- **Required-secret Enforcer**: When `NODE_ENV=production`, `assertRequiredConfig` (`src/config/validate-required-config.ts`, called from `src/main.ts`) crashes the container at boot — listing every problem at once — unless all of `JWT_SECRET` (not the `insecure-dev-secret` default), `DATABASE_URL` (not the local `postgres:postgres@localhost` default), `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_WEBHOOK_SECRET`, `ESCROW_CONTRACT_ID` and `TREASURY_SECRET` are set to real values. This closes the silent-failure gap where, for example, an empty `GITHUB_WEBHOOK_SECRET` made the app boot "healthy" while rejecting 100% of webhook deliveries. You **must** provide these when running the production container, e.g.:
   ```bash
-  docker run -p 3000:3000 -e JWT_SECRET="your-highly-secure-random-jwt-key" mergefi-backend:latest
+  docker run -p 3000:3000 \
+    -e JWT_SECRET="your-highly-secure-random-jwt-key" \
+    -e DATABASE_URL="postgresql://user:pass@db-host:5432/mergefi" \
+    -e GITHUB_CLIENT_ID=... -e GITHUB_CLIENT_SECRET=... \
+    -e GITHUB_WEBHOOK_SECRET=... \
+    -e ESCROW_CONTRACT_ID=... -e TREASURY_SECRET=... \
+    mergefi-backend:latest
   ```
 
 ### 4. Running Tests
@@ -320,7 +326,8 @@ npm run migration:revert
 - [ ] Move GitHub sync from a static PAT to a GitHub App installation-token flow for multi-org, least-privilege access.
 - [ ] Deploy the real escrow contract from `mergefi-contracts` and drop the Soroban dry-run fallback.
 - [ ] Replace the single `TREASURY_SECRET` signer with a proper signing service (KMS / multi-sig) before handling real funds.
-- [ ] Add a scheduled job for `BountiesService.expireOverdue()` (deadline sweeps) and recurring `MaintenancePool` deposits.
+- [x] ~~Add a scheduled job for `BountiesService.expireOverdue()` (deadline sweeps).~~ See `BountyExpiryScheduler` (hourly `@Cron`).
+- [ ] Add a scheduled job for recurring `MaintenancePool` deposits.
 - [ ] Add role-based authorization guards (currently JWT-authenticated but not role-scoped) to maintainer/sponsor-only endpoints.
 - [ ] Add pagination/filtering to list endpoints (bounties, milestones, pools) as data volume grows.
 - [ ] Weighted (not just even) per-issue milestone budget distribution.

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -7,6 +7,7 @@ import {
   Repository as RepositoryEntity,
 } from '../common/entities';
 import { BountyStatus } from '../common/enums';
+import { computeContributorStats } from '../common/stats/contributor-stats.util';
 
 export interface ContributorAnalytics {
   lifetimeEarnings: number;
@@ -33,21 +34,6 @@ export class AnalyticsService {
       where: { claimedById: userId },
     });
     const paid = claimed.filter((b) => b.status === BountyStatus.PAID);
-    const merged = claimed.filter((b) =>
-      [BountyStatus.MERGED, BountyStatus.PAID].includes(b.status),
-    );
-
-    const lifetimeEarnings = paid.reduce((sum, b) => sum + Number(b.amount), 0);
-    const mergeRate =
-      claimed.length > 0 ? (merged.length / claimed.length) * 100 : 0;
-
-    const reviewTimes = merged
-      .filter((b) => b.claimedAt && b.mergedAt)
-      .map((b) => (b.mergedAt!.getTime() - b.claimedAt!.getTime()) / 3_600_000);
-    const avgReviewTimeHours =
-      reviewTimes.length > 0
-        ? reviewTimes.reduce((a, b) => a + b, 0) / reviewTimes.length
-        : 0;
 
     const issues = claimed.length
       ? await this.issueRepo.find({
@@ -55,15 +41,11 @@ export class AnalyticsService {
           relations: { repository: true },
         })
       : [];
+
+    const stats = computeContributorStats(claimed, issues);
+
+    const lifetimeEarnings = paid.reduce((sum, b) => sum + Number(b.amount), 0);
     const repoIds = new Set(issues.map((i) => i.repositoryId));
-    const orgs = new Set(
-      issues.map((i) => i.repository?.owner).filter(Boolean),
-    );
-    const languages = issues.reduce<Record<string, number>>((acc, issue) => {
-      const lang = issue.repository?.primaryLanguage;
-      if (lang) acc[lang] = (acc[lang] ?? 0) + 1;
-      return acc;
-    }, {});
 
     const heatmapMap = new Map<string, number>();
     for (const bounty of paid) {
@@ -91,10 +73,10 @@ export class AnalyticsService {
     return {
       lifetimeEarnings,
       repoCount: repoIds.size,
-      orgCount: orgs.size,
-      mergeRate,
-      avgReviewTimeHours,
-      languages,
+      orgCount: stats.orgs.length,
+      mergeRate: stats.completionRate,
+      avgReviewTimeHours: stats.avgReviewTimeHours,
+      languages: stats.languages,
       heatmap,
       topClients,
     };

--- a/src/bounties/bounties.module.ts
+++ b/src/bounties/bounties.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Bounty, Team, User } from '../common/entities';
 import { BountiesService } from './bounties.service';
 import { BountiesController } from './bounties.controller';
+import { BountyExpiryScheduler } from './bounty-expiry.scheduler';
 import { EscrowModule } from '../escrow/escrow.module';
 import { AuthModule } from '../auth/auth.module';
 
@@ -13,7 +14,7 @@ import { AuthModule } from '../auth/auth.module';
     AuthModule,
   ],
   controllers: [BountiesController],
-  providers: [BountiesService],
+  providers: [BountiesService, BountyExpiryScheduler],
   exports: [BountiesService],
 })
 export class BountiesModule {}

--- a/src/bounties/bounty-expiry.scheduler.ts
+++ b/src/bounties/bounty-expiry.scheduler.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { BountiesService } from './bounties.service';
+
+/**
+ * Runs `BountiesService.expireOverdue()` on a schedule.
+ *
+ * Without this the deadline sweep is dead code — nothing in the application
+ * ever calls it, so a bounty past its deadline keeps its
+ * OPEN/FUNDED/CLAIMED status forever (#152). Mirrors the hourly `@Cron`
+ * sweep in `IdempotencyCleanupService`.
+ *
+ * This is deliberately independent of (and runs prior to) any on-chain
+ * auto-refund follow-up for expired FUNDED bounties (#26): the local status
+ * flip has to happen regardless.
+ */
+@Injectable()
+export class BountyExpiryScheduler {
+  private readonly logger = new Logger(BountyExpiryScheduler.name);
+
+  constructor(private readonly bountiesService: BountiesService) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async sweepOverdueBounties(): Promise<void> {
+    const expired = await this.bountiesService.expireOverdue();
+    if (expired > 0) {
+      this.logger.log(`Expired ${expired} overdue bounty(ies)`);
+    }
+  }
+}

--- a/src/common/stats/contributor-stats.util.ts
+++ b/src/common/stats/contributor-stats.util.ts
@@ -1,0 +1,81 @@
+import { Bounty, Issue } from '../entities';
+import { BountyStatus } from '../enums';
+
+/** Bounty statuses that count as a completed (merged) contribution. */
+export const MERGED_BOUNTY_STATUSES: readonly BountyStatus[] = [
+  BountyStatus.MERGED,
+  BountyStatus.PAID,
+];
+
+export interface ContributorStats {
+  /** Bounties the contributor claimed — the denominator for `completionRate`. */
+  claimedCount: number;
+  /** Claimed bounties that reached MERGED or PAID. */
+  mergedCount: number;
+  /** `mergedCount / claimedCount * 100` (0 when nothing was claimed). */
+  completionRate: number;
+  /** Mean hours between `claimedAt` and `mergedAt` over merged bounties (0 when none). */
+  avgReviewTimeHours: number;
+  /** Count of the passed issues per repository primary language. */
+  languages: Record<string, number>;
+  /** De-duplicated repository owners across the passed issues. */
+  orgs: string[];
+}
+
+/**
+ * Single implementation of the "contributor lifetime stats" computation that
+ * `ReputationService.computeAndSave` and `AnalyticsService.forContributor`
+ * both need (#166). Previously each service re-implemented the merge rate,
+ * the (byte-for-byte identical) average-review-time arithmetic, and the
+ * per-language / per-org reduction over a separately re-fetched set of the
+ * same issues.
+ *
+ * Callers pass the contributor's claimed bounties and the linked issues
+ * (each with its `repository` relation loaded). Anything caller-specific —
+ * paid earnings, on-time delivery %, payout heatmaps, top clients,
+ * distinct-repo counts — stays in the caller.
+ */
+export function computeContributorStats(
+  claimedBounties: Bounty[],
+  issues: Issue[],
+): ContributorStats {
+  const merged = claimedBounties.filter((b) =>
+    MERGED_BOUNTY_STATUSES.includes(b.status),
+  );
+
+  const completionRate =
+    claimedBounties.length > 0
+      ? (merged.length / claimedBounties.length) * 100
+      : 0;
+
+  const reviewTimes = merged
+    .filter((b) => b.claimedAt && b.mergedAt)
+    .map((b) => (b.mergedAt!.getTime() - b.claimedAt!.getTime()) / 3_600_000);
+  const avgReviewTimeHours =
+    reviewTimes.length > 0
+      ? reviewTimes.reduce((a, b) => a + b, 0) / reviewTimes.length
+      : 0;
+
+  const languages = issues.reduce<Record<string, number>>((acc, issue) => {
+    const lang = issue.repository?.primaryLanguage;
+    if (lang) acc[lang] = (acc[lang] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const orgs = [
+    ...new Set(
+      issues
+        .map((issue) => issue.repository?.owner)
+        .filter((owner): owner is string => Boolean(owner)),
+    ),
+  ];
+
+  return {
+    claimedCount: claimedBounties.length,
+    mergedCount: merged.length,
+    completionRate,
+    avgReviewTimeHours,
+    languages,
+    orgs,
+  };
+}

--- a/src/config/validate-required-config.ts
+++ b/src/config/validate-required-config.ts
@@ -1,0 +1,124 @@
+import { AppConfig } from './configuration';
+
+/**
+ * JWT secret fallback baked into {@link AppConfig} for local development.
+ * Booting production with this value still in place is refused.
+ */
+export const INSECURE_DEFAULT_JWT_SECRET = 'insecure-dev-secret';
+
+/**
+ * DATABASE_URL fallback baked into configuration.ts for local development —
+ * a local Postgres with the well-known `postgres:postgres` credentials.
+ * Booting production still pointed at this is refused: it would silently try
+ * to connect to whatever is listening on localhost:5432.
+ */
+export const DEFAULT_LOCAL_DATABASE_URL =
+  'postgresql://postgres:postgres@localhost:5432/mergefi';
+
+export interface ConfigIssue {
+  /** The environment variable the operator needs to set. */
+  key: string;
+  /** Human-readable explanation of what breaks while it is unset. */
+  message: string;
+}
+
+type RequiredConfig = Pick<
+  AppConfig,
+  'env' | 'jwt' | 'github' | 'stellar' | 'database'
+>;
+
+/**
+ * Collects every required-in-production configuration problem — not just the
+ * single JWT_SECRET check that used to live inline in `main.ts` (#153).
+ *
+ * Each of these secrets fails *silently* today: an empty
+ * `GITHUB_WEBHOOK_SECRET` makes `verifyGithubSignature` reject 100% of
+ * incoming webhook deliveries; empty `TREASURY_SECRET`/`ESCROW_CONTRACT_ID`
+ * pin `SorobanClientService` to permanent dry-run mode (escrow calls never
+ * touch the chain); a default `DATABASE_URL` connects to a local Postgres
+ * with default credentials. None of that surfaces at boot without this pass.
+ *
+ * Returns an empty array outside production, or when the configuration is
+ * safe to start with.
+ */
+export function collectConfigIssues(config: RequiredConfig): ConfigIssue[] {
+  const issues: ConfigIssue[] = [];
+  if (config.env !== 'production') return issues;
+
+  const requireNonEmpty = (
+    key: string,
+    value: string | null | undefined,
+    consequence: string,
+  ): void => {
+    if (!value || value.trim() === '') {
+      issues.push({
+        key,
+        message: `${key} is unset — ${consequence}`,
+      });
+    }
+  };
+
+  if (config.jwt.secret === INSECURE_DEFAULT_JWT_SECRET) {
+    issues.push({
+      key: 'JWT_SECRET',
+      message:
+        'JWT_SECRET is still the insecure dev default — set a long random value',
+    });
+  } else {
+    requireNonEmpty('JWT_SECRET', config.jwt.secret, 'session tokens cannot be signed');
+  }
+
+  if (
+    !config.database.url ||
+    config.database.url === DEFAULT_LOCAL_DATABASE_URL
+  ) {
+    issues.push({
+      key: 'DATABASE_URL',
+      message:
+        'DATABASE_URL is unset or still the local-dev default — production would connect to localhost:5432 with default postgres:postgres credentials',
+    });
+  }
+
+  requireNonEmpty(
+    'GITHUB_WEBHOOK_SECRET',
+    config.github.webhookSecret,
+    'every incoming GitHub webhook delivery is rejected by signature verification',
+  );
+  requireNonEmpty(
+    'GITHUB_CLIENT_ID',
+    config.github.clientId,
+    'GitHub OAuth login cannot be completed',
+  );
+  requireNonEmpty(
+    'GITHUB_CLIENT_SECRET',
+    config.github.clientSecret,
+    'GitHub OAuth login cannot be completed',
+  );
+  requireNonEmpty(
+    'ESCROW_CONTRACT_ID',
+    config.stellar.escrowContractId,
+    'escrow calls run in dry-run mode and never settle on-chain',
+  );
+  requireNonEmpty(
+    'TREASURY_SECRET',
+    config.stellar.treasurySecret,
+    'escrow release/refund transactions cannot be signed',
+  );
+
+  return issues;
+}
+
+/**
+ * Fails fast and loudly when any required-in-production secret is missing,
+ * listing every problem at once rather than one boot attempt per fix.
+ */
+export function assertRequiredConfig(config: RequiredConfig): void {
+  const issues = collectConfigIssues(config);
+  if (issues.length === 0) return;
+
+  const detail = issues.map((issue) => `  - ${issue.message}`).join('\n');
+  throw new Error(
+    `Refusing to start in production with an incomplete configuration:\n${detail}\n` +
+      'Set the environment variables listed above (see .env.example) and restart.',
+  );
+}

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -258,6 +258,57 @@ export class EscrowService {
     return payment;
   }
 
+  /**
+   * Pays a reward out of a maintenance pool's running balance.
+   *
+   * The real `mergefi-maintenance-pool` contract has no
+   * LOCKED-escrow-with-partial-release concept: it accrues an on-chain
+   * `balance` through repeated `deposit()` calls and pays out via
+   * `withdraw(pool_id, recipient, amount)` against the live balance, with no
+   * pre-`lock` step and no "fully released" terminal state (#163).
+   *
+   * So unlike {@link releasePartial} — which is milestone-shaped: it checks
+   * the cumulative payouts against a fixed locked `escrow.amount` and flips
+   * the escrow to RELEASED once they reach it — this call:
+   *   - invokes the pool contract's `withdraw`, not `release`;
+   *   - leaves the escrow row LOCKED (it mirrors an open, still-funded pool,
+   *     not a one-off lock that closes out);
+   *   - does not enforce a ceiling here. The spendable balance is tracked by
+   *     `MaintenancePoolService` on `pool.balance` and checked there before
+   *     this is called.
+   */
+  async poolWithdraw(
+    escrowId: string,
+    amount: string,
+    recipientAddress: string,
+    recipientId?: string,
+  ): Promise<Payment> {
+    const escrow = await this.getOrThrow(escrowId);
+    this.assertLocked(escrow);
+    this.assertValidAmount(amount);
+    await this.assertRecipientsMatchUsers([{ recipientAddress, recipientId }]);
+
+    const result = await this.invokeOnLockedEscrow(escrow, 'poolWithdraw', () =>
+      this.soroban.invoke('withdraw', [
+        escrow.maintenancePoolId ?? escrow.id,
+        recipientAddress,
+        this.toStroops(amount),
+      ]),
+    );
+
+    return this.paymentRepo.save(
+      this.paymentRepo.create({
+        escrowId: escrow.id,
+        recipientId: recipientId ?? null,
+        recipientAddress,
+        amount,
+        asset: escrow.asset,
+        status: PaymentStatus.CONFIRMED,
+        txHash: result.txHash,
+      }),
+    );
+  }
+
   /** Refunds the full escrowed amount back to the original funder. */
   async refund(escrowId: string): Promise<Escrow> {
     const escrow = await this.getOrThrow(escrowId);

--- a/src/escrow/soroban-client.service.ts
+++ b/src/escrow/soroban-client.service.ts
@@ -25,17 +25,24 @@ export interface ContractInvocationResult {
  * escrow smart contract deployed by the sibling `mergefi-contracts` repo.
  *
  * TODO(mergefi-contracts): this client assumes a contract exposing
- * `fund`, `release`, `refund`, and `split_release` functions with the
- * signatures documented below. Adjust argument encoding once the real
+ * `fund`, `release`, `refund`, `split_release` and `withdraw` functions with
+ * the signatures documented below. Adjust argument encoding once the real
  * contract interface (from the Soroban contract's generated bindings) is
  * available. Until ESCROW_CONTRACT_ID is configured, calls run in
  * "simulate-only" dry-run mode and never submit a real transaction.
  *
- * Expected contract interface (Rust, illustrative):
+ * Expected bounty/milestone escrow interface (Rust, illustrative):
  *   fn fund(env: Env, funder: Address, bounty_id: BytesN<32>, amount: i128, token: Address)
  *   fn release(env: Env, bounty_id: BytesN<32>, recipient: Address) -> i128
  *   fn split_release(env: Env, bounty_id: BytesN<32>, recipients: Vec<Address>, bps: Vec<u32>) -> i128
  *   fn refund(env: Env, bounty_id: BytesN<32>) -> i128
+ *
+ * The `mergefi-maintenance-pool` contract is a distinct deposit/withdraw
+ * model (no lock step, no split): a running on-chain balance topped up by
+ * any sponsor via repeated `deposit()`, paid out by an admin against the
+ * live balance — see `EscrowService.poolWithdraw` (#163):
+ *   fn deposit(env: Env, sponsor: Address, pool_id: BytesN<32>, amount: i128, token: Address)
+ *   fn withdraw(env: Env, pool_id: BytesN<32>, recipient: Address, amount: i128) -> i128
  */
 @Injectable()
 export class SorobanClientService {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,8 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { AppConfig } from './config/configuration';
+import { assertRequiredConfig } from './config/validate-required-config';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
-
-const INSECURE_DEFAULT_JWT_SECRET = 'insecure-dev-secret';
 
 const LOG_LEVEL_MAP: Record<string, string[]> = {
   error: ['error'],
@@ -31,12 +30,18 @@ async function bootstrap() {
   const env = configService.get('env', { infer: true });
   const logLevel = configService.get('logLevel', { infer: true });
   app.useLogger(resolveLogLevels(logLevel));
-  const jwtSecret = configService.get('jwt', { infer: true }).secret;
-  if (env === 'production' && jwtSecret === INSECURE_DEFAULT_JWT_SECRET) {
-    throw new Error(
-      'Refusing to start in production with the default JWT_SECRET. Set a real JWT_SECRET env var.',
-    );
-  }
+
+  // Fail fast and loudly if *any* required-in-production secret is missing —
+  // not just JWT_SECRET. An empty GITHUB_WEBHOOK_SECRET, TREASURY_SECRET,
+  // ESCROW_CONTRACT_ID, GITHUB_CLIENT_SECRET or a default DATABASE_URL all
+  // otherwise let the app boot "healthy" while silently misbehaving (#153).
+  assertRequiredConfig({
+    env,
+    jwt: configService.get('jwt', { infer: true }),
+    github: configService.get('github', { infer: true }),
+    stellar: configService.get('stellar', { infer: true }),
+    database: configService.get('database', { infer: true }),
+  });
 
   app.use(helmet());
   app.enableCors({

--- a/src/maintenance-pool/maintenance-pool.service.spec.ts
+++ b/src/maintenance-pool/maintenance-pool.service.spec.ts
@@ -14,7 +14,7 @@ describe('MaintenancePoolService', () => {
     create: jest.Mock;
     find: jest.Mock;
   };
-  let escrowService: { fund: jest.Mock; releasePartial: jest.Mock };
+  let escrowService: { fund: jest.Mock; poolWithdraw: jest.Mock };
   let issueRepo: { findOne: jest.Mock };
 
   beforeEach(async () => {
@@ -28,7 +28,7 @@ describe('MaintenancePoolService', () => {
     };
     escrowService = {
       fund: jest.fn(),
-      releasePartial: jest.fn(),
+      poolWithdraw: jest.fn(),
     };
     issueRepo = {
       findOne: jest.fn().mockResolvedValue({
@@ -226,7 +226,7 @@ describe('MaintenancePoolService', () => {
       await expect(
         service.assignReward('pool-1', 'issue-1', '10', 'GRECIPIENT'),
       ).rejects.toThrow(BadRequestException);
-      expect(escrowService.releasePartial).not.toHaveBeenCalled();
+      expect(escrowService.poolWithdraw).not.toHaveBeenCalled();
     });
 
     it('rejects when the requested amount exceeds the pool balance', async () => {
@@ -239,7 +239,7 @@ describe('MaintenancePoolService', () => {
       await expect(
         service.assignReward('pool-1', 'issue-1', '100', 'GRECIPIENT'),
       ).rejects.toThrow(BadRequestException);
-      expect(escrowService.releasePartial).not.toHaveBeenCalled();
+      expect(escrowService.poolWithdraw).not.toHaveBeenCalled();
     });
 
     it('releases the reward and decrements the balance', async () => {
@@ -248,7 +248,7 @@ describe('MaintenancePoolService', () => {
         balance: '100',
         escrowId: 'escrow-1',
       });
-      escrowService.releasePartial.mockResolvedValue({ id: 'payment-1' });
+      escrowService.poolWithdraw.mockResolvedValue({ id: 'payment-1' });
 
       const payment = await service.assignReward(
         'pool-1',
@@ -258,7 +258,7 @@ describe('MaintenancePoolService', () => {
         'user-1',
       );
 
-      expect(escrowService.releasePartial).toHaveBeenCalledWith(
+      expect(escrowService.poolWithdraw).toHaveBeenCalledWith(
         'escrow-1',
         '30',
         'GRECIPIENT',
@@ -285,7 +285,7 @@ describe('MaintenancePoolService', () => {
       await expect(
         service.assignReward('pool-1', 'issue-1', '10', 'GRECIPIENT'),
       ).rejects.toThrow(BadRequestException);
-      expect(escrowService.releasePartial).not.toHaveBeenCalled();
+      expect(escrowService.poolWithdraw).not.toHaveBeenCalled();
     });
 
     it('rejects an issue outside the pool repository', async () => {
@@ -304,7 +304,7 @@ describe('MaintenancePoolService', () => {
       await expect(
         service.assignReward('pool-1', 'issue-1', '10', 'GRECIPIENT'),
       ).rejects.toThrow(BadRequestException);
-      expect(escrowService.releasePartial).not.toHaveBeenCalled();
+      expect(escrowService.poolWithdraw).not.toHaveBeenCalled();
     });
 
     // Regression baseline for #51 (MaintenancePool.balance is a
@@ -331,7 +331,7 @@ describe('MaintenancePoolService', () => {
         sharedPoolRow.balance = pool.balance;
         return Promise.resolve(pool);
       });
-      escrowService.releasePartial.mockResolvedValue({ id: 'payment-x' });
+      escrowService.poolWithdraw.mockResolvedValue({ id: 'payment-x' });
 
       await Promise.all([
         service.assignReward('pool-1', 'issue-1', '100', 'GRECIPIENT_A'),

--- a/src/maintenance-pool/maintenance-pool.service.ts
+++ b/src/maintenance-pool/maintenance-pool.service.ts
@@ -111,7 +111,11 @@ export class MaintenancePoolService {
       );
     }
 
-    const payment = await this.escrowService.releasePartial(
+    // A maintenance pool is a running on-chain balance (deposit/withdraw),
+    // not a milestone-style fixed lock that gets partially released and then
+    // closed out — so pay the reward via the pool contract's `withdraw`,
+    // leaving the escrow LOCKED for the next reward (#163).
+    const payment = await this.escrowService.poolWithdraw(
       pool.escrowId,
       amount,
       recipientAddress,

--- a/src/reputation/reputation.service.ts
+++ b/src/reputation/reputation.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Bounty, Issue, ReputationSnapshot } from '../common/entities';
 import { BountyStatus } from '../common/enums';
+import { computeContributorStats } from '../common/stats/contributor-stats.util';
 
 @Injectable()
 export class ReputationService {
@@ -21,24 +22,20 @@ export class ReputationService {
     const claimedBounties = await this.bountyRepo.find({
       where: { claimedById: userId },
     });
+    const issues = claimedBounties.length
+      ? await this.issueRepo.find({
+          where: claimedBounties.map((b) => ({ id: b.issueId })),
+          relations: { repository: true },
+        })
+      : [];
+
+    const stats = computeContributorStats(claimedBounties, issues);
+
     const merged = claimedBounties.filter((b) =>
       [BountyStatus.MERGED, BountyStatus.PAID].includes(b.status),
     );
     const paid = claimedBounties.filter((b) => b.status === BountyStatus.PAID);
-
     const totalEarnings = paid.reduce((sum, b) => sum + Number(b.amount), 0);
-    const completionRate =
-      claimedBounties.length > 0
-        ? (merged.length / claimedBounties.length) * 100
-        : 0;
-
-    const reviewTimes = merged
-      .filter((b) => b.claimedAt && b.mergedAt)
-      .map((b) => (b.mergedAt!.getTime() - b.claimedAt!.getTime()) / 3_600_000);
-    const avgReviewTimeHours =
-      reviewTimes.length > 0
-        ? reviewTimes.reduce((a, b) => a + b, 0) / reviewTimes.length
-        : 0;
 
     const onTime = merged.filter(
       (b) => !b.deadline || (b.mergedAt && b.mergedAt <= b.deadline),
@@ -46,34 +43,18 @@ export class ReputationService {
     const onTimeDeliveryPercentage =
       merged.length > 0 ? (onTime.length / merged.length) * 100 : 0;
 
-    const issueIds = claimedBounties.map((b) => b.issueId);
-    const issues = issueIds.length
-      ? await this.issueRepo.find({
-          where: issueIds.map((id) => ({ id })),
-          relations: { repository: true },
-        })
-      : [];
-    const orgsContributedTo = [
-      ...new Set(issues.map((i) => i.repository?.owner).filter(Boolean)),
-    ];
-    const languages = issues.reduce<Record<string, number>>((acc, issue) => {
-      const lang = issue.repository?.primaryLanguage;
-      if (lang) acc[lang] = (acc[lang] ?? 0) + 1;
-      return acc;
-    }, {});
-
     const snapshot = this.snapshotRepo.create({
       userId,
       totalEarnings: totalEarnings.toFixed(7),
-      mergedPrCount: merged.length,
+      mergedPrCount: stats.mergedCount,
       openBountiesClaimed: claimedBounties.filter((b) =>
         [BountyStatus.CLAIMED, BountyStatus.IN_REVIEW].includes(b.status),
       ).length,
-      completionRate: completionRate.toFixed(2),
-      avgReviewTimeHours: avgReviewTimeHours.toFixed(2),
+      completionRate: stats.completionRate.toFixed(2),
+      avgReviewTimeHours: stats.avgReviewTimeHours.toFixed(2),
       onTimeDeliveryPercentage: onTimeDeliveryPercentage.toFixed(2),
-      languages,
-      orgsContributedTo,
+      languages: stats.languages,
+      orgsContributedTo: stats.orgs,
     });
     return this.snapshotRepo.save(snapshot);
   }


### PR DESCRIPTION
Fixes #153, Fixes #152, Fixes #163, Fixes #166.

Each issue is addressed in its own set of commits; no behavioural change outside the areas described.

## #153 — no startup validation for required secrets beyond JWT_SECRET

`bootstrap()` only refused to start on a default `JWT_SECRET`; every other production secret fell back to `''` (or, for `DATABASE_URL`, a hardcoded local-Postgres string) with no boot-time check, so the app booted "healthy" while, e.g., an empty `GITHUB_WEBHOOK_SECRET` silently rejected 100% of webhook deliveries.

- New `src/config/validate-required-config.ts`: `collectConfigIssues()` gathers **every** required-in-production problem at once (JWT_SECRET default/empty, default/empty `DATABASE_URL`, empty `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` / `GITHUB_WEBHOOK_SECRET` / `ESCROW_CONTRACT_ID` / `TREASURY_SECRET`); `assertRequiredConfig()` throws once, listing all of them.
- `main.ts` calls `assertRequiredConfig(...)` in place of the inline JWT-only guard. No-ops outside `NODE_ENV=production`.
- `.env.example` / README document the guard.

## #152 — `BountiesService.expireOverdue()` is dead code

Nothing ever called it — no `@Cron`, no route — so overdue bounties kept their `OPEN`/`FUNDED`/`CLAIMED` status forever.

- New `BountyExpiryScheduler` (`@Cron(CronExpression.EVERY_HOUR)`), mirroring `IdempotencyCleanupService`, registered in `BountiesModule`.
- Independent of / prior to any on-chain auto-refund follow-up (#26).
- README roadmap item ticked.

## #163 — maintenance-pool `assignReward` has no counterpart in the real contract

`assignReward()` called `EscrowService.releasePartial()` — milestone-shaped: it checks cumulative payouts against a fixed locked `escrow.amount` and flips the escrow to `RELEASED` once they reach it. The real `mergefi-maintenance-pool` contract is deposit/withdraw: a running on-chain balance, paid out via `withdraw(pool_id, recipient, amount)` with no lock step and no terminal "released" state.

- New `EscrowService.poolWithdraw()`: invokes the pool contract's `withdraw`, records a `Payment`, and leaves the escrow `LOCKED` (it mirrors an open, still-funded pool). Spendable balance stays tracked/checked by `MaintenancePoolService` on `pool.balance`.
- `assignReward()` now calls `poolWithdraw()`.
- `soroban-client.service.ts` documents the distinct maintenance-pool `deposit`/`withdraw` interface.
- `maintenance-pool.service.spec.ts` updated for the new call.

## #166 — duplicated contributor-stats computation

`ReputationService.computeAndSave` and `AnalyticsService.forContributor` independently implemented the same merge/completion rate, the byte-for-byte identical average-review-time arithmetic, and the per-language / per-org reduction over a separately re-fetched set of the same issues.

- New `src/common/stats/contributor-stats.util.ts` — `computeContributorStats(bounties, issues)` returns `{ claimedCount, mergedCount, completionRate, avgReviewTimeHours, languages, orgs }`.
- Both services consume it; caller-specific pieces (paid earnings, on-time %, heatmap, top clients, distinct-repo count) stay in the caller.
