### PR TITLE
fix: atomic escrow ledger writes, shared split validator, hardened CI scans (#154, #167, #155, #165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          # Full history so the secret scan can inspect every commit, not
+          # just the working tree — a credential committed and later removed
+          # is invisible to a shallow checkout (#155).
+          fetch-depth: 0
 
       - name: Setup Node.js v24
         uses: actions/setup-node@v4
@@ -34,29 +39,20 @@ jobs:
           node-version: 24
           cache: 'npm'
 
-      - name: Scan for Hardcoded Secrets
+      - name: Scan for Hardcoded Secrets (gitleaks, full history)
+        env:
+          GITLEAKS_VERSION: 8.28.0
         run: |
-          echo "Scanning codebase for potential hardcoded secrets..."
-          
-          # Detect Stellar Secret Keys (starts with S, 56 characters, uppercase A-Z, digits 2-7)
-          if grep -r -E "\bS[A-D][A-Z2-7]{54}\b" --exclude-dir={node_modules,dist,coverage,.git} .; then
-            echo "::error::Potential Stellar Secret Key detected in codebase!"
-            exit 1
-          fi
-          
-          # Detect PEM Private Keys
-          if grep -r -E "(-+BEGIN [A-Z ]+ PRIVATE KEY-+)" --exclude-dir={node_modules,dist,coverage,.git} .; then
-            echo "::error::Potential PEM Private Key detected in codebase!"
-            exit 1
-          fi
-          
-          # Detect GitHub Personal Access Tokens (Legacy and Fine-grained)
-          if grep -r -E "(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{82})" --exclude-dir={node_modules,dist,coverage,.git} .; then
-            echo "::error::Potential GitHub Token detected in codebase!"
-            exit 1
-          fi
-          
-          echo "Secret scan completed. No secrets detected."
+          set -euo pipefail
+          echo "Downloading gitleaks v${GITLEAKS_VERSION}..."
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          # `gitleaks git` walks the full commit history (not just the current
+          # tree) using gitleaks' maintained rule set — AWS keys, generic
+          # high-entropy tokens, connection strings, webhook URLs, JWTs, etc.
+          # — replacing the three hand-rolled regexes this step used to run.
+          ./gitleaks git . --redact --verbose --exit-code 1
         shell: bash
 
       - name: Install Dependencies
@@ -80,21 +76,19 @@ jobs:
           NODE_ENV: test
         run: npm run test:cov
 
-      - name: Run E2E Tests (Conditional)
+      - name: Run E2E Tests
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/mergefi
           NODE_ENV: test
-          # Map GitHub Secrets if configured in the repository
-          GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
         run: |
-          if [ -z "$GITHUB_CLIENT_ID" ] || [ -z "$GITHUB_CLIENT_SECRET" ]; then
-            echo "=========================================================================="
-            echo "WARNING: Skipping E2E tests because external GitHub OAuth secrets are not"
-            echo "configured in the repository settings (GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET)."
-            echo "To enable E2E tests in CI, please set these secrets in GitHub."
-            echo "=========================================================================="
-          else
-            npm run test:e2e
+          # The e2e specs build their TestingModule from mocked providers and
+          # overrideGuard(...)-stubbed auth — none drive a real passport-github2
+          # handshake, so GITHUB_CLIENT_ID/SECRET were never the right gate
+          # (#165). What they actually need is a reachable Postgres, which the
+          # `postgres` service container above always provides.
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "Skipping E2E tests: DATABASE_URL is not set."
+            exit 0
           fi
+          npm run test:e2e
         shell: bash

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+# gitleaks configuration for the CI "Scan for Hardcoded Secrets" step (#155).
+#
+# Extends gitleaks' maintained default rule set (AWS keys, generic
+# high-entropy tokens, DB connection strings, Slack/Discord webhooks, JWTs,
+# private keys, ...) and adds a project rule for Stellar secret keys, which
+# the previous hand-rolled grep specifically looked for.
+#
+# The allowlist below only covers deliberately-fake values in tests,
+# examples, and SDK mocks. It must never be widened to silence a real
+# finding in application code or in git history.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "stellar-secret-key"
+description = "Stellar / Soroban secret seed (S... 56 chars, base32 alphabet)"
+regex = '''\bS[A-D][A-Z2-7]{54}\b'''
+keywords = ["S"]
+
+[allowlist]
+description = "Fake credentials in tests, examples and mocks"
+paths = [
+  '''\.env\.example$''',
+  '''(^|/)test/''',
+  '''\.spec\.ts$''',
+  '''\.e2e-spec\.ts$''',
+  '''\.mock\.(js|ts)$''',
+  '''(^|/)test/mocks/''',
+]
+regexes = [
+  # Placeholder values shipped in .env.example / docs.
+  '''change-me[a-z-]*''',
+  '''your-[a-z-]+''',
+  '''insecure-dev-secret''',
+  # Well-known local Postgres dev DSN used throughout the repo.
+  '''postgres:postgres@localhost''',
+]

--- a/src/common/validators/split-percentage.validator.spec.ts
+++ b/src/common/validators/split-percentage.validator.spec.ts
@@ -1,0 +1,55 @@
+import { BadRequestException } from '@nestjs/common';
+import { validatePercentageSplits } from './split-percentage.validator';
+
+describe('validatePercentageSplits', () => {
+  it('accepts a list that sums to exactly 100', () => {
+    expect(() =>
+      validatePercentageSplits([
+        { percentage: 40 },
+        { percentage: 40 },
+        { percentage: 20 },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('accepts a list within floating-point tolerance of 100', () => {
+    expect(() =>
+      validatePercentageSplits([
+        { percentage: 33.33 },
+        { percentage: 33.33 },
+        { percentage: 33.34 },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('rejects an empty list', () => {
+    expect(() => validatePercentageSplits([])).toThrow(BadRequestException);
+  });
+
+  it('rejects a list that does not sum to 100', () => {
+    expect(() =>
+      validatePercentageSplits([{ percentage: 40 }, { percentage: 40 }]),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects a zero or negative percentage', () => {
+    expect(() =>
+      validatePercentageSplits([{ percentage: 0 }, { percentage: 100 }]),
+    ).toThrow(BadRequestException);
+    expect(() =>
+      validatePercentageSplits([{ percentage: -10 }, { percentage: 110 }]),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects a percentage above 100 even when the total is 100', () => {
+    expect(() =>
+      validatePercentageSplits([{ percentage: 150 }, { percentage: -50 }]),
+    ).toThrow(BadRequestException);
+  });
+
+  it('uses the supplied label in the error message', () => {
+    expect(() =>
+      validatePercentageSplits([{ percentage: 10 }], 'team member split'),
+    ).toThrow(/team member split/);
+  });
+});

--- a/src/common/validators/split-percentage.validator.ts
+++ b/src/common/validators/split-percentage.validator.ts
@@ -1,0 +1,45 @@
+import { BadRequestException } from '@nestjs/common';
+
+/** Anything carrying a `percentage` field — a team member split or an escrow split recipient. */
+export interface PercentageSplit {
+  percentage: number;
+}
+
+/** Percentages are considered to sum to 100 when within this absolute tolerance. */
+export const SPLIT_PERCENTAGE_TOLERANCE = 0.01;
+
+/**
+ * Single source of truth for percentage-split validation (#167).
+ *
+ * Both places this codebase collects percentage-based splits —
+ * `CreateTeamDto.members` (via `TeamsService`) and `SplitReleaseDto.recipients`
+ * (via `EscrowService.splitRelease`) — must answer the same question: is this a
+ * non-empty list where every entry is in `(0, 100]` and the total is 100 within
+ * {@link SPLIT_PERCENTAGE_TOLERANCE}? Previously `team-split.util.ts` and
+ * `EscrowService.assertValidSplits` each reimplemented it, and the two drifted
+ * in strictness. This function is now the only implementation; both callers
+ * delegate here.
+ *
+ * @param splits list of `{ percentage }` entries to validate
+ * @param label noun used in error messages (e.g. `"team member split"`,
+ *   `"split release"`); defaults to `"split"`
+ */
+export function validatePercentageSplits(
+  splits: PercentageSplit[],
+  label = 'split',
+): void {
+  if (splits.length === 0) {
+    throw new BadRequestException(`At least one ${label} entry is required`);
+  }
+  if (splits.some((s) => s.percentage <= 0 || s.percentage > 100)) {
+    throw new BadRequestException(
+      `Each ${label} percentage must be greater than 0 and at most 100`,
+    );
+  }
+  const total = splits.reduce((sum, s) => sum + s.percentage, 0);
+  if (Math.abs(total - 100) > SPLIT_PERCENTAGE_TOLERANCE) {
+    throw new BadRequestException(
+      `${label} percentages must sum to 100, got ${total.toFixed(2)}`,
+    );
+  }
+}

--- a/src/escrow/escrow.service.spec.ts
+++ b/src/escrow/escrow.service.spec.ts
@@ -1,17 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { BadRequestException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
 import { EscrowService } from './escrow.service';
 import { SorobanClientService } from './soroban-client.service';
 import { Escrow, Payment, User } from '../common/entities';
-import { AssetType, EscrowStatus } from '../common/enums';
-import { Escrow, Payment } from '../common/entities';
 import { AssetType, EscrowStatus, PaymentStatus } from '../common/enums';
 
 describe('EscrowService', () => {
   let service: EscrowService;
   let escrowRepo: { create: jest.Mock; save: jest.Mock; findOne: jest.Mock };
-  let paymentRepo: { create: jest.Mock; save: jest.Mock };
   let userRepo: { find: jest.Mock };
   let paymentRepo: {
     create: jest.Mock;
@@ -19,6 +17,7 @@ describe('EscrowService', () => {
     find: jest.Mock;
   };
   let soroban: { invoke: jest.Mock };
+  let dataSource: { transaction: jest.Mock };
 
   beforeEach(async () => {
     escrowRepo = {
@@ -47,6 +46,16 @@ describe('EscrowService', () => {
         status: 'SUCCESS',
       }),
     };
+    // The transaction manager routes save(Entity, data) to the matching repo
+    // mock so existing escrowRepo.save / paymentRepo.save assertions still hold.
+    const manager = {
+      save: jest.fn((entity: unknown, data: unknown) =>
+        entity === Payment ? paymentRepo.save(data) : escrowRepo.save(data),
+      ),
+    };
+    dataSource = {
+      transaction: jest.fn((fn: (m: typeof manager) => unknown) => fn(manager)),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -54,6 +63,7 @@ describe('EscrowService', () => {
         { provide: getRepositoryToken(Escrow), useValue: escrowRepo },
         { provide: getRepositoryToken(Payment), useValue: paymentRepo },
         { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: DataSource, useValue: dataSource },
         { provide: SorobanClientService, useValue: soroban },
       ],
     }).compile();
@@ -230,6 +240,52 @@ describe('EscrowService', () => {
           amount: '50',
         }),
       );
+    });
+
+    it('writes the escrow status and the Payment in one transaction (#154)', async () => {
+      escrowRepo.findOne.mockResolvedValue({
+        id: 'escrow-3',
+        status: EscrowStatus.LOCKED,
+        amount: '50',
+        asset: AssetType.USDC,
+        bountyId: 'bounty-3',
+      });
+
+      await service.release('escrow-3', 'GRECIPIENT', 'user-1');
+
+      expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a recipientId with no matching user before invoking Soroban (#154)', async () => {
+      escrowRepo.findOne.mockResolvedValue({
+        id: 'escrow-3',
+        status: EscrowStatus.LOCKED,
+        amount: '50',
+        asset: AssetType.USDC,
+        bountyId: 'bounty-3',
+      });
+      userRepo.find.mockResolvedValue([]);
+
+      await expect(
+        service.release('escrow-3', 'GRECIPIENT', 'ghost-user'),
+      ).rejects.toThrow(BadRequestException);
+      expect(soroban.invoke).not.toHaveBeenCalled();
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('propagates a Payment-insert failure out of the transaction (#154)', async () => {
+      escrowRepo.findOne.mockResolvedValue({
+        id: 'escrow-3',
+        status: EscrowStatus.LOCKED,
+        amount: '50',
+        asset: AssetType.USDC,
+        bountyId: 'bounty-3',
+      });
+      paymentRepo.save.mockRejectedValueOnce(new Error('FK violation'));
+
+      await expect(
+        service.release('escrow-3', 'GRECIPIENT', 'user-1'),
+      ).rejects.toThrow('FK violation');
     });
   });
 
@@ -446,6 +502,43 @@ describe('EscrowService', () => {
       const splitArgs = invokeCall[1] as unknown[];
       const bps = splitArgs[2] as number[];
       expect(bps.reduce((a, b) => a + b, 0)).toBe(10_000);
+    });
+
+    it('writes the escrow status and every recipient Payment in one transaction (#154)', async () => {
+      escrowRepo.findOne.mockResolvedValue({
+        id: 'escrow-4',
+        status: EscrowStatus.LOCKED,
+        amount: '100',
+        asset: AssetType.USDC,
+        bountyId: 'bounty-4',
+      });
+
+      await service.splitRelease('escrow-4', [
+        { recipientAddress: 'GA', percentage: 50 },
+        { recipientAddress: 'GB', percentage: 50 },
+      ]);
+
+      expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates a mid-loop Payment failure out of the split transaction (#154)', async () => {
+      escrowRepo.findOne.mockResolvedValue({
+        id: 'escrow-4',
+        status: EscrowStatus.LOCKED,
+        amount: '100',
+        asset: AssetType.USDC,
+        bountyId: 'bounty-4',
+      });
+      paymentRepo.save
+        .mockResolvedValueOnce({ id: 'payment-1' })
+        .mockRejectedValueOnce(new Error('FK violation on recipient 2'));
+
+      await expect(
+        service.splitRelease('escrow-4', [
+          { recipientAddress: 'GA', percentage: 50 },
+          { recipientAddress: 'GB', percentage: 50 },
+        ]),
+      ).rejects.toThrow('FK violation on recipient 2');
     });
   });
 });

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -4,8 +4,8 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { Escrow, Payment, User } from '../common/entities';
 import { AssetType, EscrowStatus, PaymentStatus } from '../common/enums';
 import {
@@ -14,6 +14,7 @@ import {
   isValidMoneyAmount,
   stroopsToAmount,
 } from '../common/validators/money.validator';
+import { validatePercentageSplits } from '../common/validators/split-percentage.validator';
 import { SorobanClientService } from './soroban-client.service';
 import { apportionBasisPoints, splitStroops } from './split-math.util';
 
@@ -49,6 +50,7 @@ export class EscrowService {
     @InjectRepository(Payment)
     private readonly paymentRepo: Repository<Payment>,
     @InjectRepository(User) private readonly userRepo: Repository<User>,
+    @InjectDataSource() private readonly dataSource: DataSource,
     private readonly soroban: SorobanClientService,
   ) {}
 
@@ -113,21 +115,29 @@ export class EscrowService {
       ]),
     );
 
-    escrow.status = EscrowStatus.RELEASED;
-    escrow.releaseTxHash = result.txHash;
-    escrow.releasedAt = new Date();
-    await this.escrowRepo.save(escrow);
+    // The on-chain release already succeeded; the local ledger must record
+    // (escrow -> RELEASED) and the Payment row atomically, or neither, so a
+    // Payment-insert failure can never leave a permanently-mismarked escrow
+    // with no record of who was paid (#154).
+    await this.dataSource.transaction(async (manager) => {
+      escrow.status = EscrowStatus.RELEASED;
+      escrow.releaseTxHash = result.txHash;
+      escrow.releasedAt = new Date();
+      await manager.save(Escrow, escrow);
 
-    const payment = this.paymentRepo.create({
-      escrowId: escrow.id,
-      recipientId: recipientId ?? null,
-      recipientAddress,
-      amount: escrow.amount,
-      asset: escrow.asset,
-      status: PaymentStatus.CONFIRMED,
-      txHash: result.txHash,
+      await manager.save(
+        Payment,
+        this.paymentRepo.create({
+          escrowId: escrow.id,
+          recipientId: recipientId ?? null,
+          recipientAddress,
+          amount: escrow.amount,
+          asset: escrow.asset,
+          status: PaymentStatus.CONFIRMED,
+          txHash: result.txHash,
+        }),
+      );
     });
-    await this.paymentRepo.save(payment);
 
     return escrow;
   }
@@ -168,27 +178,36 @@ export class EscrowService {
     const shares = splitStroops(totalStroops, bps);
     this.reconcileSplitResult(escrow.id, totalStroops, result.returnValue);
 
-    escrow.status = EscrowStatus.RELEASED;
-    escrow.releaseTxHash = result.txHash;
-    escrow.releasedAt = new Date();
-    escrow.metadata = { ...(escrow.metadata ?? {}), splitRelease: result };
-    await this.escrowRepo.save(escrow);
-
+    // Atomic: the escrow flips to RELEASED and every recipient's Payment row
+    // is written in one transaction, so a mid-loop insert failure can no
+    // longer leave a RELEASED escrow with only some recipients recorded
+    // (#154).
     const payments: Payment[] = [];
-    for (let i = 0; i < recipients.length; i++) {
-      const recipient = recipients[i];
-      const payment = this.paymentRepo.create({
-        escrowId: escrow.id,
-        recipientId: recipient.recipientId ?? null,
-        recipientAddress: recipient.recipientAddress,
-        amount: stroopsToAmount(shares[i]),
-        asset: escrow.asset,
-        splitPercentage: (bps[i] / 100).toFixed(2),
-        status: PaymentStatus.CONFIRMED,
-        txHash: result.txHash,
-      });
-      payments.push(await this.paymentRepo.save(payment));
-    }
+    await this.dataSource.transaction(async (manager) => {
+      escrow.status = EscrowStatus.RELEASED;
+      escrow.releaseTxHash = result.txHash;
+      escrow.releasedAt = new Date();
+      escrow.metadata = { ...(escrow.metadata ?? {}), splitRelease: result };
+      await manager.save(Escrow, escrow);
+
+      for (let i = 0; i < recipients.length; i++) {
+        const recipient = recipients[i];
+        const payment = await manager.save(
+          Payment,
+          this.paymentRepo.create({
+            escrowId: escrow.id,
+            recipientId: recipient.recipientId ?? null,
+            recipientAddress: recipient.recipientAddress,
+            amount: stroopsToAmount(shares[i]),
+            asset: escrow.asset,
+            splitPercentage: (bps[i] / 100).toFixed(2),
+            status: PaymentStatus.CONFIRMED,
+            txHash: result.txHash,
+          }),
+        );
+        payments.push(payment);
+      }
+    });
     return payments;
   }
 
@@ -236,24 +255,31 @@ export class EscrowService {
         ]),
     );
 
-    const payment = await this.paymentRepo.save(
-      this.paymentRepo.create({
-        escrowId: escrow.id,
-        recipientId: recipientId ?? null,
-        recipientAddress,
-        amount,
-        asset: escrow.asset,
-        status: PaymentStatus.CONFIRMED,
-        txHash: result.txHash,
-      }),
-    );
+    // The Payment insert and the (conditional) escrow-status flip share one
+    // transaction so the two can't diverge — same guarantee as release()
+    // and splitRelease() (#154).
+    let payment!: Payment;
+    await this.dataSource.transaction(async (manager) => {
+      payment = await manager.save(
+        Payment,
+        this.paymentRepo.create({
+          escrowId: escrow.id,
+          recipientId: recipientId ?? null,
+          recipientAddress,
+          amount,
+          asset: escrow.asset,
+          status: PaymentStatus.CONFIRMED,
+          txHash: result.txHash,
+        }),
+      );
 
-    if (releasedSoFar + requested >= Number(escrow.amount) - 1e-7) {
-      escrow.status = EscrowStatus.RELEASED;
-      escrow.releaseTxHash = result.txHash;
-      escrow.releasedAt = new Date();
-      await this.escrowRepo.save(escrow);
-    }
+      if (releasedSoFar + requested >= Number(escrow.amount) - 1e-7) {
+        escrow.status = EscrowStatus.RELEASED;
+        escrow.releaseTxHash = result.txHash;
+        escrow.releasedAt = new Date();
+        await manager.save(Escrow, escrow);
+      }
+    });
 
     return payment;
   }
@@ -349,10 +375,11 @@ export class EscrowService {
 
   /**
    * recipientId and recipientAddress must describe the same payee: whenever a
-   * user id is supplied, its address is required to match the Stellar address
-   * on file for that user (#92). Without this cross-check, on-chain funds
-   * could go to an unrelated address while Payment rows attribute them to the
-   * given user id.
+   * user id is supplied, the user must exist and its address must match the
+   * Stellar address on file (#92). Runs before the Soroban invocation so a
+   * client-trusted, non-existent recipientId is rejected up front rather
+   * than surfacing as a foreign-key violation on the Payment insert *after*
+   * funds have already moved on-chain (#154).
    */
   private async assertRecipientsMatchUsers(
     recipients: { recipientAddress: string; recipientId?: string }[],
@@ -371,8 +398,13 @@ export class EscrowService {
 
     for (const r of recipients) {
       if (!r.recipientId) continue;
-      const onFile = byId.get(r.recipientId)?.stellarAddress ?? null;
-      if (!onFile || onFile !== r.recipientAddress) {
+      const user = byId.get(r.recipientId);
+      if (!user) {
+        throw new BadRequestException(
+          `recipientId ${r.recipientId} does not correspond to a known user`,
+        );
+      }
+      if (user.stellarAddress !== r.recipientAddress) {
         throw new BadRequestException(
           `recipientAddress does not match the Stellar address on file for user ${r.recipientId}`,
         );
@@ -407,22 +439,14 @@ export class EscrowService {
     }
   }
 
-  /** Validates that split percentages sum to 100.00, within floating point tolerance. */
+  /**
+   * Validates that split percentages sum to 100.00 (within tolerance), with
+   * every entry in `(0, 100]`. Delegates to the shared
+   * {@link validatePercentageSplits} — the same implementation
+   * `TeamsService` uses for `CreateTeamDto.members` (#167).
+   */
   assertValidSplits(recipients: SplitRecipient[]): void {
-    if (recipients.length === 0) {
-      throw new BadRequestException(
-        'At least one recipient is required for a split release',
-      );
-    }
-    const total = recipients.reduce((sum, r) => sum + r.percentage, 0);
-    if (Math.abs(total - 100) > 0.01) {
-      throw new BadRequestException(
-        `Split percentages must sum to 100, got ${total.toFixed(2)}`,
-      );
-    }
-    if (recipients.some((r) => r.percentage <= 0)) {
-      throw new BadRequestException('Split percentages must be positive');
-    }
+    validatePercentageSplits(recipients, 'split release');
   }
 
   /**

--- a/src/teams/team-split.util.ts
+++ b/src/teams/team-split.util.ts
@@ -1,23 +1,17 @@
-import { BadRequestException } from '@nestjs/common';
+import {
+  PercentageSplit,
+  validatePercentageSplits,
+} from '../common/validators/split-percentage.validator';
 
-export interface SplitLike {
-  percentage: number;
-}
+export type SplitLike = PercentageSplit;
 
-/** Validates that a set of team member split percentages sums to exactly 100 (within tolerance). */
+/**
+ * Validates that a set of team member split percentages sums to exactly 100
+ * (within tolerance), with every entry in `(0, 100]`.
+ *
+ * Thin wrapper over the shared {@link validatePercentageSplits} — the single
+ * implementation also used by `EscrowService.assertValidSplits` (#167).
+ */
 export function validateSplitPercentages(splits: SplitLike[]): void {
-  if (splits.length === 0) {
-    throw new BadRequestException('A team must have at least one member split');
-  }
-  if (splits.some((s) => s.percentage <= 0 || s.percentage > 100)) {
-    throw new BadRequestException(
-      'Each split percentage must be between 0 and 100',
-    );
-  }
-  const total = splits.reduce((sum, s) => sum + s.percentage, 0);
-  if (Math.abs(total - 100) > 0.01) {
-    throw new BadRequestException(
-      `Team split percentages must sum to 100, got ${total.toFixed(2)}`,
-    );
-  }
+  validatePercentageSplits(splits, 'team member split');
 }


### PR DESCRIPTION
Resolves #154
Resolves #167
Resolves #155
Resolves #165

## #154 — atomic escrow-status + Payment writes

`release()` and `splitRelease()` saved the escrow as `RELEASED` *before* creating the `Payment` row(s). A `Payment` insert failure (e.g. a client-trusted `recipientId` with no matching `User` → FK violation) then left the escrow permanently mismarked as `RELEASED` — funds moved on-chain — with the payout record missing entirely, or in `splitRelease` only partially written.

- `release`, `splitRelease`, `releasePartial` now wrap the escrow-status update and Payment insert(s) in a single `dataSource.transaction(...)`, so it's all-or-nothing.
- `assertRecipientsMatchUsers` now rejects a non-existent `recipientId` with an explicit error **before** the Soroban call, instead of letting it surface as a post-payout FK violation.
- `releasePartial` already ordered Payment-before-status; it's now transactional too, for consistency across the three siblings.

## #167 — one shared split-percentage validator

`team-split.util.ts::validateSplitPercentages` and `escrow.service.ts::assertValidSplits` independently reimplemented "non-empty, every entry in `(0, 100]`, sums to 100 within 0.01". New `src/common/validators/split-percentage.validator.ts` (alongside `money.validator.ts` / `stellar-address.validator.ts`) is the single implementation; both call sites delegate to it, so `CreateTeamDto.members` and `SplitReleaseDto.recipients` validation is consistent by construction.

## #155 — real secret scanning

The CI "Scan for Hardcoded Secrets" step grepped the working tree for 3 narrow patterns and never saw git history. Replaced with **gitleaks** (maintained ruleset — AWS keys, generic high-entropy tokens, connection strings, webhook URLs, JWTs, …) run as `gitleaks git .` over the **full history** (`fetch-depth: 0` added to checkout). `.gitleaks.toml` re-adds a Stellar-secret-key rule and allowlists deliberately-fake values in `test/`, `*.spec.ts`, `*.mock.*`, and `.env.example`.

> Note: scanning full history may surface pre-existing findings in older commits that the old scan couldn't see — that's the point of the issue, but such findings would need history remediation (e.g. `git filter-repo`) separately from this PR.

## #165 — correct e2e gate

No `test/*.e2e-spec.ts` drives a real `passport-github2` handshake (they all use mocked providers + `overrideGuard`), so `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` was never the right gate. The e2e job now gates on `DATABASE_URL` (always provided by the `postgres` service container) and drops the unused OAuth secret mapping.

## Incidental
`escrow.service.spec.ts` had duplicated `entities`/`enums` imports and two `paymentRepo` declarations from an earlier `main` merge (`1b58a30`) that fails `tsc` — collapsed to one set.

Branched on current `main` (`c0ff5ff`).
