### PR TITLE
fix: CI push trigger, webhook_events indexes, batched team-split insert, distinct release method names (#156, #149, #150, #159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - main
+  # Also run on commits that land on main by any path (admin bypass,
+  # misconfigured or not-yet-enabled branch protection), so the secret scan,
+  # lint, build and tests still gate the default branch (#156).
+  push:
+    branches:
+      - main
 
 jobs:
   ci:

--- a/src/common/entities/webhook-event.entity.ts
+++ b/src/common/entities/webhook-event.entity.ts
@@ -2,12 +2,24 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { WebhookEventStatus } from '../enums';
 
-/** Audit log of every inbound webhook, verified or not, for replay/debugging. */
+/**
+ * Audit log of every inbound webhook, verified or not, for replay/debugging.
+ *
+ * This is an append-only, never-pruned table (unlike `IdempotencyKey`, which
+ * has TTL cleanup), so operational reads must not full-scan it (#149):
+ *  - `IDX_webhook_events_type_status` serves "by event type / status"
+ *    breakdowns (e.g. a metrics job, an admin triage list).
+ *  - `IDX_webhook_events_status_received_at` serves the "recent FAILED
+ *    events" query — filter on `status`, order by `receivedAt DESC`.
+ */
 @Entity('webhook_events')
+@Index('IDX_webhook_events_type_status', ['eventType', 'status'])
+@Index('IDX_webhook_events_status_received_at', ['status', 'receivedAt'])
 export class WebhookEvent {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/database/migrations/1784900000000-AddWebhookEventIndexes.ts
+++ b/src/database/migrations/1784900000000-AddWebhookEventIndexes.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Indexes `webhook_events` for operational reads (#149).
+ *
+ * The table is append-only and never pruned, so it grows without bound. Only
+ * `deliveryId` was indexed (implicitly, via its unique constraint); any query
+ * filtering on `eventType` / `status` / `receivedAt` — an admin triage view,
+ * a per-type metrics job, "did webhook X ever arrive" debugging — full-scanned
+ * it.
+ *
+ *  - `IDX_webhook_events_type_status` (eventType, status): type/status breakdowns.
+ *  - `IDX_webhook_events_status_received_at` (status, receivedAt): the common
+ *    "recent failures" query — filter status, order by receivedAt.
+ */
+export class AddWebhookEventIndexes1784900000000 implements MigrationInterface {
+  name = 'AddWebhookEventIndexes1784900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_webhook_events_type_status"
+      ON "webhook_events" ("eventType", "status")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_webhook_events_status_received_at"
+      ON "webhook_events" ("status", "receivedAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_webhook_events_status_received_at"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_webhook_events_type_status"`,
+    );
+  }
+}

--- a/src/escrow/escrow.service.spec.ts
+++ b/src/escrow/escrow.service.spec.ts
@@ -4,14 +4,11 @@ import { BadRequestException } from '@nestjs/common';
 import { EscrowService } from './escrow.service';
 import { SorobanClientService } from './soroban-client.service';
 import { Escrow, Payment, User } from '../common/entities';
-import { AssetType, EscrowStatus } from '../common/enums';
-import { Escrow, Payment } from '../common/entities';
 import { AssetType, EscrowStatus, PaymentStatus } from '../common/enums';
 
 describe('EscrowService', () => {
   let service: EscrowService;
   let escrowRepo: { create: jest.Mock; save: jest.Mock; findOne: jest.Mock };
-  let paymentRepo: { create: jest.Mock; save: jest.Mock };
   let userRepo: { find: jest.Mock };
   let paymentRepo: {
     create: jest.Mock;
@@ -224,6 +221,11 @@ describe('EscrowService', () => {
       const escrow = await service.release('escrow-3', 'GRECIPIENT', 'user-1');
 
       expect(escrow.status).toBe(EscrowStatus.RELEASED);
+      // Distinct from releasePartial's 'release_partial' method name (#159).
+      expect(soroban.invoke).toHaveBeenCalledWith('release', [
+        'bounty-3',
+        'GRECIPIENT',
+      ]);
       expect(paymentRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({
           recipientAddress: 'GRECIPIENT',
@@ -254,7 +256,7 @@ describe('EscrowService', () => {
         'user-1',
       );
 
-      expect(soroban.invoke).toHaveBeenCalledWith('release', [
+      expect(soroban.invoke).toHaveBeenCalledWith('release_partial', [
         'milestone-1',
         'GRECIPIENT',
         300_000_000n,
@@ -304,7 +306,7 @@ describe('EscrowService', () => {
 
       await service.releasePartial('escrow-partial', '60.0000000', 'GB');
 
-      expect(soroban.invoke).toHaveBeenNthCalledWith(2, 'release', [
+      expect(soroban.invoke).toHaveBeenNthCalledWith(2, 'release_partial', [
         'milestone-1',
         'GB',
         600_000_000n,

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -229,7 +229,11 @@ export class EscrowService {
       escrow,
       'releasePartial',
       () =>
-        this.soroban.invoke('release', [
+        // Distinct on-chain method name from release()'s two-arg `release`
+        // (#159): a partial release carries an amount and is a different
+        // contract entrypoint, not an overload — so a contract implementer
+        // isn't left guessing which arg shape `release` is authoritative.
+        this.soroban.invoke('release_partial', [
           escrow.milestoneId ?? escrow.bountyId ?? escrow.id,
           recipientAddress,
           this.toStroops(amount),

--- a/src/teams/teams.service.spec.ts
+++ b/src/teams/teams.service.spec.ts
@@ -8,7 +8,7 @@ import { BountyStatus } from '../common/enums';
 describe('TeamsService', () => {
   let service: TeamsService;
   let teamRepo: { findOne: jest.Mock; save: jest.Mock; create: jest.Mock };
-  let splitRepo: { save: jest.Mock; create: jest.Mock };
+  let splitRepo: { save: jest.Mock; create: jest.Mock; delete: jest.Mock };
   let bountyRepo: { findOne: jest.Mock; save: jest.Mock };
 
   beforeEach(async () => {
@@ -21,9 +21,12 @@ describe('TeamsService', () => {
     };
     splitRepo = {
       create: jest.fn((s: Partial<TeamMemberSplit>) => s),
-      save: jest.fn((s: Partial<TeamMemberSplit>) =>
-        Promise.resolve({ id: `split-${s.userId}`, ...s }),
+      save: jest.fn((s: Partial<TeamMemberSplit> | Partial<TeamMemberSplit>[]) =>
+        Array.isArray(s)
+          ? Promise.resolve(s.map((x) => ({ id: `split-${x.userId}`, ...x })))
+          : Promise.resolve({ id: `split-${s.userId}`, ...s }),
       ),
+      delete: jest.fn().mockResolvedValue(undefined),
     };
     bountyRepo = {
       findOne: jest.fn(),
@@ -67,22 +70,23 @@ describe('TeamsService', () => {
       expect(teamRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'Team A', createdById: 'creator-1' }),
       );
-      expect(splitRepo.save).toHaveBeenCalledTimes(2);
+      // One batched save with the whole array, not one call per member (#150).
+      expect(splitRepo.save).toHaveBeenCalledTimes(1);
       expect(splitRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          teamId: 't1',
-          userId: 'u1',
-          role: 'frontend',
-          percentage: '60.00',
-        }),
-      );
-      expect(splitRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          teamId: 't1',
-          userId: 'u2',
-          role: null,
-          percentage: '40.00',
-        }),
+        expect.arrayContaining([
+          expect.objectContaining({
+            teamId: 't1',
+            userId: 'u1',
+            role: 'frontend',
+            percentage: '60.00',
+          }),
+          expect.objectContaining({
+            teamId: 't1',
+            userId: 'u2',
+            role: null,
+            percentage: '40.00',
+          }),
+        ]),
       );
       expect(team.splits).toHaveLength(2);
     });

--- a/src/teams/teams.service.ts
+++ b/src/teams/teams.service.ts
@@ -24,16 +24,17 @@ export class TeamsService {
       }),
     );
 
-    team.splits = await Promise.all(
+    // One batched save (inside TypeORM's implicit transaction) rather than
+    // N independently-committing INSERTs — a mid-way failure now rolls back
+    // to zero splits instead of leaving a partial, invalid set (#150).
+    team.splits = await this.splitRepo.save(
       dto.members.map((m) =>
-        this.splitRepo.save(
-          this.splitRepo.create({
-            teamId: team.id,
-            userId: m.userId,
-            role: m.role ?? null,
-            percentage: m.percentage.toFixed(2),
-          }),
-        ),
+        this.splitRepo.create({
+          teamId: team.id,
+          userId: m.userId,
+          role: m.role ?? null,
+          percentage: m.percentage.toFixed(2),
+        }),
       ),
     );
 
@@ -60,17 +61,15 @@ export class TeamsService {
     // Remove existing splits
     await this.splitRepo.delete({ teamId: team.id });
 
-    // Create new splits
-    team.splits = await Promise.all(
+    // Create new splits — one batched save, same rationale as create() (#150).
+    team.splits = await this.splitRepo.save(
       members.map((m) =>
-        this.splitRepo.save(
-          this.splitRepo.create({
-            teamId: team.id,
-            userId: m.userId,
-            role: m.role ?? null,
-            percentage: m.percentage.toFixed(2),
-          }),
-        ),
+        this.splitRepo.create({
+          teamId: team.id,
+          userId: m.userId,
+          role: m.role ?? null,
+          percentage: m.percentage.toFixed(2),
+        }),
       ),
     );
 


### PR DESCRIPTION
Resolves #156
Resolves #149
Resolves #150
Resolves #159

## #156 — CI also runs on push to `main`
`ci.yml`'s `on:` had only `pull_request: [main]` — a direct push to `main` (admin bypass, misconfigured/not-yet-enabled branch protection) ran through none of the pipeline, including the secret scan. Added a `push: branches: [main]` trigger alongside it.

## #149 — index the `webhook_events` audit table
It's append-only and never pruned (unlike `IdempotencyKey`), yet only `deliveryId` was indexed. Added `@Index` on `(eventType, status)` and `(status, receivedAt)` plus migration `1784900000000` — covering per-type breakdowns and the "recent FAILED events" query.

## #150 — batch the team-split insert
`TeamsService.create` (and `updateSplits`) issued one `INSERT` per member via `Promise.all(map(splitRepo.save(...)))` — N round-trips, N independently-committing statements (a mid-way failure left a partial split set). Replaced with a single `splitRepo.save(members.map(create))`, which batches and runs inside TypeORM's implicit transaction.

## #159 — distinct on-chain method names for `release` vs partial release
`release()` called `soroban.invoke('release', [ref, addr])` (2 args) and `releasePartial()` called `soroban.invoke('release', [ref, addr, amount])` (3 args) — same method name, different arity, un-caught at the backend layer. `releasePartial()` now invokes `'release_partial'`, so a contract implementer isn't left guessing which arg shape `'release'` is authoritative.

## Incidental
`escrow.service.spec.ts` had duplicated `entities`/`enums` imports and two `paymentRepo` declarations from an earlier `main` merge (`1b58a30`) that fails `tsc` — collapsed to one set.

Branched on current `main` (`c0ff5ff`). Not built locally.
