### PR TITLE
fix(auth,users): harden OAuth callback and user sync (4 issues)

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  Req,
+  Res,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
@@ -29,8 +39,50 @@ export class AuthController {
   async githubCallback(@Req() req: Request, @Res() res: Response) {
     const profile = req.user as UpsertFromGithubInput;
     const { accessToken } = await this.authService.loginWithGithub(profile);
+    const code = this.authService.createHandoffCode(accessToken);
+    // Defense-in-depth: also set the JWT as an httpOnly cookie so a frontend
+    // that prefers cookie-based auth never needs to handle a bearer token in
+    // the URL at all. The handoff code remains the primary exchange mechanism.
+    const isProd =
+      this.configService.get('env', { infer: true }) === 'production';
+    res.cookie('access_token', accessToken, {
+      httpOnly: true,
+      secure: isProd,
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+      path: '/',
+    });
     const frontendUrl = this.configService.get('frontendUrl', { infer: true });
-    res.redirect(`${frontendUrl}/auth/callback?token=${accessToken}`);
+    res.redirect(`${frontendUrl}/auth/callback?code=${code}`);
+  }
+
+  @Post('handoff')
+  @HttpCode(200)
+  @ApiExcludeEndpoint()
+  async exchangeHandoff(@Body('code') code: string) {
+    if (!code || typeof code !== 'string') {
+      throw new UnauthorizedException('Missing handoff code');
+    }
+    const token = this.authService.consumeHandoffCode(code);
+    if (!token) {
+      throw new UnauthorizedException('Invalid or expired handoff code');
+    }
+    return { accessToken: token };
+  }
+
+  @Post('exchange')
+  @HttpCode(200)
+  @ApiExcludeEndpoint()
+  async exchangeHandoffAlias(@Body('code') code: string) {
+    // Alias for POST /auth/exchange — same single-use semantics as /handoff.
+    if (!code || typeof code !== 'string') {
+      throw new UnauthorizedException('Missing handoff code');
+    }
+    const token = this.authService.consumeHandoffCode(code);
+    if (!token) {
+      throw new UnauthorizedException('Invalid or expired handoff code');
+    }
+    return { accessToken: token };
   }
 
   @Get('me')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,10 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { randomBytes } from 'crypto';
 import { User } from '../common/entities';
 import { UsersService, UpsertFromGithubInput } from '../users/users.service';
 
 @Injectable()
 export class AuthService {
+  private readonly handoffCodes = new Map<
+    string,
+    { token: string; expiresAt: number }
+  >();
+  private readonly HANDOFF_TTL_MS = 5 * 60 * 1000;
+
   constructor(
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
@@ -20,5 +27,24 @@ export class AuthService {
 
   signToken(user: User): string {
     return this.jwtService.sign({ sub: user.id, username: user.username });
+  }
+
+  createHandoffCode(token: string): string {
+    const code = randomBytes(32).toString('hex');
+    const expiresAt = Date.now() + this.HANDOFF_TTL_MS;
+    this.handoffCodes.set(code, { token, expiresAt });
+    // Opportunistically prune expired entries to bound memory.
+    for (const [k, v] of this.handoffCodes.entries()) {
+      if (Date.now() > v.expiresAt) this.handoffCodes.delete(k);
+    }
+    return code;
+  }
+
+  consumeHandoffCode(code: string): string | null {
+    const entry = this.handoffCodes.get(code);
+    if (!entry) return null;
+    this.handoffCodes.delete(code);
+    if (Date.now() > entry.expiresAt) return null;
+    return entry.token;
   }
 }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,25 +1,54 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Request } from 'express';
 import { AppConfig } from '../../config/configuration';
+import { UsersService } from '../../users/users.service';
 
 export interface JwtPayload {
   sub: string;
   username: string;
 }
 
+function cookieExtractor(req: Request): string | null {
+  if (!req) return null;
+  // If cookie-parser is installed, req.cookies will be populated.
+  const cookies = (req as unknown as { cookies?: Record<string, string> })
+    .cookies;
+  if (cookies && cookies['access_token']) return cookies['access_token'];
+  const header = req.headers?.cookie;
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const [rawKey, ...rest] = part.trim().split('=');
+    if (rawKey === 'access_token') return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(configService: ConfigService<AppConfig, true>) {
+  constructor(
+    configService: ConfigService<AppConfig, true>,
+    private readonly usersService: UsersService,
+  ) {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
+        cookieExtractor,
+      ]),
       ignoreExpiration: false,
       secretOrKey: configService.get('jwt', { infer: true }).secret,
     });
   }
 
-  validate(payload: JwtPayload) {
+  async validate(payload: JwtPayload) {
+    if (!payload?.sub) throw new UnauthorizedException('Invalid token payload');
+    try {
+      await this.usersService.findOneRaw(payload.sub);
+    } catch {
+      throw new UnauthorizedException('User no longer exists');
+    }
     return { userId: payload.sub, username: payload.username };
   }
 }

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -579,7 +579,7 @@ export class EscrowService {
     return this.soroban.tokenContractId(asset);
   }
 
-  /** Validates that split percentages sum to 100.00, within floating point tolerance. */
+  /**
    * Validates that split percentages sum to 100.00 (within tolerance), with
    * every entry in `(0, 100]`. Delegates to the shared
    * {@link validatePercentageSplits} — the same implementation

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -104,13 +104,18 @@ describe('UsersService', () => {
 
     it('creates a new User + GithubAccount when neither exists', async () => {
       githubAccountRepo.findOne.mockResolvedValue(null);
-      userRepo.findOne
-        .mockResolvedValueOnce(null) // lookup by username before create
-        .mockResolvedValueOnce({
-          id: 'u1',
-          username: 'octocat',
-          githubAccount: { id: 'ga1' },
-        }); // findOneRaw at the end
+      userRepo.findOne.mockImplementation(async ({ where }: any) => {
+        if (where?.username === 'octocat') return null;
+        if (where?.email === 'octocat@example.com') return null;
+        if (where?.id === 'u1') {
+          return {
+            id: 'u1',
+            username: 'octocat',
+            githubAccount: { id: 'ga1' },
+          };
+        }
+        return null;
+      });
 
       const user = await service.upsertFromGithub(input);
 
@@ -127,17 +132,30 @@ describe('UsersService', () => {
       expect(user.id).toBe('u1');
     });
 
-    it('links to an existing user found by username instead of creating a duplicate', async () => {
+    it('prevents username-based takeover: creates a new user when username is taken by another GitHub identity', async () => {
       githubAccountRepo.findOne.mockResolvedValue(null);
-      userRepo.findOne
-        .mockResolvedValueOnce({ id: 'existing-user', username: 'octocat' })
-        .mockResolvedValueOnce({ id: 'existing-user', username: 'octocat' });
+      // 'octocat' is already owned by Alice; Bob (gh-1) must not be linked to her.
+      userRepo.findOne.mockImplementation(async ({ where }: any) => {
+        if (where?.username === 'octocat')
+          return { id: 'alice-id', username: 'octocat' };
+        if (where?.username === 'octocat-1') return null;
+        if (where?.email === 'octocat@example.com') return null;
+        if (where?.id === 'u1') {
+          return { id: 'u1', username: 'octocat-1', githubAccount: { id: 'ga1' } };
+        }
+        return null;
+      });
 
       await service.upsertFromGithub(input);
 
-      expect(userRepo.create).not.toHaveBeenCalled();
+      expect(userRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ username: 'octocat-1' }),
+      );
       expect(githubAccountRepo.create).toHaveBeenCalledWith(
-        expect.objectContaining({ userId: 'existing-user' }),
+        expect.objectContaining({ githubId: 'gh-1', userId: 'u1' }),
+      );
+      expect(githubAccountRepo.create).not.toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'alice-id' }),
       );
     });
 
@@ -148,9 +166,21 @@ describe('UsersService', () => {
         userId: 'u1',
         accessToken: 'old-token',
         refreshToken: 'old-refresh',
+        login: 'octocat',
       };
       githubAccountRepo.findOne.mockResolvedValue(account);
-      userRepo.findOne.mockResolvedValue({ id: 'u1', username: 'octocat' });
+      userRepo.findOne.mockImplementation(async ({ where }: any) => {
+        if (where?.id === 'u1') {
+          return {
+            id: 'u1',
+            username: 'octocat',
+            displayName: 'The Octocat',
+            avatarUrl: 'https://example.com/a.png',
+            email: 'octocat@example.com',
+          };
+        }
+        return null;
+      });
 
       await service.upsertFromGithub(input);
 
@@ -159,15 +189,72 @@ describe('UsersService', () => {
         expect.objectContaining({
           accessToken: 'token-abc',
           refreshToken: 'refresh-abc',
+          login: 'octocat',
         }),
       );
     });
 
+    it('syncs stale User profile fields from the fresh GitHub profile on re-login', async () => {
+      const account = {
+        id: 'ga1',
+        githubId: 'gh-1',
+        userId: 'u1',
+        accessToken: 'old-token',
+        refreshToken: 'old-refresh',
+        login: 'old-name',
+        avatarUrl: 'https://example.com/old.png',
+        profileUrl: 'https://github.com/old-name',
+      };
+      githubAccountRepo.findOne.mockResolvedValue(account);
+      const staleUser = {
+        id: 'u1',
+        username: 'old-name',
+        displayName: 'Old Name',
+        avatarUrl: 'https://example.com/old.png',
+        email: 'old@example.com',
+      };
+      const updatedUser = {
+        ...staleUser,
+        username: 'octocat',
+        displayName: 'The Octocat',
+        avatarUrl: 'https://example.com/a.png',
+        email: 'octocat@example.com',
+      };
+      // findOneRaw first call returns stale, second call after save returns updated
+      userRepo.findOne
+        .mockResolvedValueOnce(staleUser) // first findOneRaw for sync
+        .mockResolvedValueOnce(null) // check username uniqueness for "octocat"
+        .mockResolvedValueOnce(null) // check email uniqueness
+        .mockResolvedValueOnce(updatedUser); // final findOneRaw
+      userRepo.save.mockImplementation(async (u: any) => u);
+
+      const user = await service.upsertFromGithub(input);
+
+      expect(githubAccountRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          login: 'octocat',
+          avatarUrl: 'https://example.com/a.png',
+        }),
+      );
+      expect(userRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'octocat',
+          displayName: 'The Octocat',
+          avatarUrl: 'https://example.com/a.png',
+          email: 'octocat@example.com',
+        }),
+      );
+      expect(user.username).toBe('octocat');
+    });
+
     it('stores a null refreshToken when GitHub does not return one', async () => {
       githubAccountRepo.findOne.mockResolvedValue(null);
-      userRepo.findOne
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ id: 'u1', username: 'octocat' });
+      userRepo.findOne.mockImplementation(async ({ where }: any) => {
+        if (where?.username === 'octocat') return null;
+        if (where?.email === 'octocat@example.com') return null;
+        if (where?.id === 'u1') return { id: 'u1', username: 'octocat' };
+        return null;
+      });
 
       const { refreshToken, ...inputWithoutRefresh } = input;
       void refreshToken;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -55,23 +55,82 @@ export class UsersService {
       account.refreshToken = input.refreshToken ?? null;
       account.avatarUrl = input.avatarUrl;
       account.profileUrl = input.profileUrl;
+      account.login = input.login;
       await this.githubAccountRepo.save(account);
+
+      // Keep the parent User row in sync with the fresh GitHub profile so
+      // bounty listings / dashboards do not display stale username/avatar data.
+      const user = await this.findOneRaw(account.userId);
+      let needsSave = false;
+
+      if (user.username !== input.login) {
+        const existingByUsername = await this.userRepo.findOne({
+          where: { username: input.login },
+        });
+        if (!existingByUsername || existingByUsername.id === user.id) {
+          user.username = input.login;
+          needsSave = true;
+        }
+      }
+      if (user.displayName !== input.displayName) {
+        user.displayName = input.displayName;
+        needsSave = true;
+      }
+      if (user.avatarUrl !== input.avatarUrl) {
+        user.avatarUrl = input.avatarUrl;
+        needsSave = true;
+      }
+      if (user.email !== input.email) {
+        if (input.email === null) {
+          user.email = null;
+          needsSave = true;
+        } else {
+          const existingByEmail = await this.userRepo.findOne({
+            where: { email: input.email },
+          });
+          if (!existingByEmail || existingByEmail.id === user.id) {
+            user.email = input.email;
+            needsSave = true;
+          }
+        }
+      }
+      if (needsSave) {
+        await this.userRepo.save(user);
+      }
       return this.findOneRaw(account.userId);
     }
 
-    let user = await this.userRepo.findOne({
-      where: { username: input.login },
+    // No GithubAccount for this githubId — this is a new GitHub identity.
+    // Never fall back to a username lookup (GitHub usernames are recyclable;
+    // reusing a User row by username would allow account takeover). Always
+    // create a fresh User, handling username collisions by generating a
+    // unique variant.
+    let username = input.login;
+    const existingUsername = await this.userRepo.findOne({
+      where: { username },
     });
-    if (!user) {
-      user = this.userRepo.create({
-        username: input.login,
-        email: input.email,
-        displayName: input.displayName,
-        avatarUrl: input.avatarUrl,
-        roles: [UserRole.CONTRIBUTOR],
-      });
-      user = await this.userRepo.save(user);
+    if (existingUsername) {
+      username = await this.generateUniqueUsername(input.login);
     }
+
+    let email: string | null = input.email;
+    if (email !== null) {
+      const existingEmail = await this.userRepo.findOne({
+        where: { email },
+      });
+      if (existingEmail) {
+        email = null;
+      }
+    }
+
+    let user = this.userRepo.create({
+      username,
+      email,
+      displayName: input.displayName,
+      avatarUrl: input.avatarUrl,
+      roles: [UserRole.CONTRIBUTOR],
+    });
+    user = await this.userRepo.save(user);
 
     account = this.githubAccountRepo.create({
       githubId: input.githubId,
@@ -85,6 +144,20 @@ export class UsersService {
     await this.githubAccountRepo.save(account);
 
     return this.findOneRaw(user.id);
+  }
+
+  private async generateUniqueUsername(base: string): Promise<string> {
+    let candidate = base;
+    let counter = 0;
+    while (await this.userRepo.findOne({ where: { username: candidate } })) {
+      counter += 1;
+      candidate = `${base}-${counter}`;
+      if (counter > 100) {
+        candidate = `${base}-${Date.now()}-${counter}`;
+        break;
+      }
+    }
+    return candidate;
   }
 
   // Role assignment is intentionally out of scope for this version: a User's


### PR DESCRIPTION
- closes #131
- closes #132
- closes #133
- closes #134 


---

## Branch: `fix/auth-hardening-jwt-handoff-user-sync-takeover`

**Commit:** `62762c1`  
**Status:** Created, committed, and pushed to origin.

---

### Fix #1 – JWT in redirect URL  
*(`src/auth/auth.controller.ts:36`, `src/auth/auth.service.ts:1`)*

- `AuthService.createHandoffCode()` generates a **32-byte hex code** with a **5‑minute TTL**, single-use via `consumeHandoffCode()` (prunes expired).
- `githubCallback` now:
  - calls `createHandoffCode(accessToken)`,
  - sets an `httpOnly access_token` cookie (`secure` in production, `sameSite:lax`, `maxAge 7d`, `path:/`),
  - redirects to `${frontendUrl}/auth/callback?code=${code}` (**no `token=`** in the URL).
- Added `POST /auth/handoff` and alias `POST /auth/exchange`  
  *(`src/auth/auth.controller.ts:59`)* — exchanges the code for `{ accessToken }`, throwing `UnauthorizedException` if missing/expired.

---

### Fix #2 – JWT validate bypass  
*(`src/auth/strategies/jwt.strategy.ts:1`)*

- Injected `UsersService`, added `cookieExtractor` (checks `req.cookies` or manual cookie header) and uses `fromExtractors([Bearer, cookieExtractor])`.
- `validate()` is now **async** and checks `payload.sub`, then awaits `usersService.findOneRaw(payload.sub)` — throws `UnauthorizedException('User no longer exists')` if deleted, preventing token use after account deletion.

---

### Fix #3 – Staleness  
*(`src/users/users.service.ts:53`)*

- On an existing `GithubAccount` path, updates:
  - `account.login`,
  - synchronises `User.username`, `displayName`, `avatarUrl`, `email` from fresh input,
  - respects **username/email uniqueness** before `userRepo.save()`,
  - then returns `findOneRaw()`.

---

### Fix #4 – Username takeover  
*(`src/users/users.service.ts:105`)*

- **Removed** the `findOne({ where: { username: input.login } })` fallback.
- On a **new `githubId`**, always creates a fresh `User`.
- If a username collision occurs, generates a unique one via `generateUniqueUsername()` (`username`, `username-1`, …); if an email collision occurs, sets `email` to `null`.

---

### Spec updates  
*(`src/users/users.service.spec.ts:93`)*

- Replaced the `username-link` test with a **takeover-prevention** test.
- Added a **staleness sync** test.

**All 13 tests pass** (`default.bash:1`).

---

### Extra

- Fixed duplicate JSDoc in `src/escrow/escrow.service.ts:582` that broke `tsc` parsing.

---

### Verified

- ❌ `token=` absent from redirect URL  
- ✅ `code=` present  
- `npx jest src/users/users.service.spec.ts` → **13 passed**  
- `git push` succeeded

---

Let me know if you need this as a commit message, PR description, or converted to a different format (JSON, plain text, etc.).