### PR TITLE
fix: don't resolve cross-repo closing-keyword issue refs against own …

### DIFF
--- a/src/github/github-webhooks.service.spec.ts
+++ b/src/github/github-webhooks.service.spec.ts
@@ -344,6 +344,65 @@ describe('GithubWebhooksService', () => {
     });
   });
 
+  describe('owner/repo-qualified closing keywords', () => {
+    it('resolves a closing keyword qualified with the webhook\'s own owner/repo', async () => {
+      issueRepo.findOne.mockResolvedValue({
+        id: 'issue-1',
+        bounty: { id: 'bounty-1' },
+      });
+      bountyRepo.findOne.mockResolvedValue({ id: 'bounty-1', status: 'claimed' });
+
+      const payload = {
+        action: 'closed',
+        number: 11,
+        pull_request: {
+          html_url: 'https://github.com/acme/repo/pull/11',
+          number: 11,
+          merged: true,
+          body: 'Fixes acme/repo#42',
+        },
+        repository: { id: 999, full_name: 'acme/repo' },
+      };
+
+      const event = await service.handleEvent(
+        'pull_request',
+        'delivery-same-repo-qualified',
+        payload,
+        true,
+      );
+
+      expect(bountiesService.markMergedAndRelease).toHaveBeenCalledWith(
+        'bounty-1',
+      );
+      expect(event.status).toBe(WebhookEventStatus.PROCESSED);
+    });
+
+    it('does not resolve a closing keyword qualified with a different owner/repo against this repository', async () => {
+      const payload = {
+        action: 'closed',
+        number: 12,
+        pull_request: {
+          html_url: 'https://github.com/acme/repo/pull/12',
+          number: 12,
+          merged: true,
+          body: 'Fixes some-other-org/some-other-repo#45',
+        },
+        repository: { id: 999, full_name: 'acme/repo' },
+      };
+
+      const event = await service.handleEvent(
+        'pull_request',
+        'delivery-cross-repo-qualified',
+        payload,
+        true,
+      );
+
+      expect(issueRepo.findOne).not.toHaveBeenCalled();
+      expect(bountiesService.markMergedAndRelease).not.toHaveBeenCalled();
+      expect(event.status).toBe(WebhookEventStatus.PROCESSED);
+    });
+  });
+
   describe('"issues" webhook events (#24)', () => {
     const payload = {
       action: 'edited',

--- a/src/github/github-webhooks.service.ts
+++ b/src/github/github-webhooks.service.ts
@@ -30,7 +30,7 @@ interface GithubIssuesEventPayload {
 
 /** Matches "Fixes #123", "Closes #45", "Resolves owner/repo#45" etc. in a PR body. */
 const CLOSING_KEYWORD_RE =
-  /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b\s*:?\s*(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*(?<repo>[\w.-]+\/[\w.-]+)?#(?<number>\d+)/gi;
 
 /**
  * The outcome of processing one issue number linked from a merged PR's
@@ -179,7 +179,10 @@ export class GithubWebhooksService {
     // rather than a real one (#47).
     const issueNumbers = [
       ...new Set(
-        this.extractLinkedIssueNumbers(payload.pull_request.body ?? ''),
+        this.extractLinkedIssueNumbers(
+          payload.pull_request.body ?? '',
+          payload.repository.full_name,
+        ),
       ),
     ];
     if (issueNumbers.length === 0) {
@@ -269,9 +272,31 @@ export class GithubWebhooksService {
     }
   }
 
-  private extractLinkedIssueNumbers(body: string): number[] {
+  /**
+   * A closing keyword may optionally be qualified with an owner/repo, e.g.
+   * "Fixes some-other-org/some-other-repo#45". When that qualifier is
+   * present, it must match the webhook's own repository — otherwise the
+   * reference is for an issue in a different repository entirely and must
+   * not be resolved against this one (compared case-insensitively, as
+   * GitHub owner/repo names are).
+   */
+  private extractLinkedIssueNumbers(
+    body: string,
+    repoFullName: string,
+  ): number[] {
     const matches = [...body.matchAll(CLOSING_KEYWORD_RE)];
-    return matches.map((m) => parseInt(m[3], 10));
+    const numbers: number[] = [];
+    for (const m of matches) {
+      const repoQualifier = m.groups?.repo;
+      if (
+        repoQualifier &&
+        repoQualifier.toLowerCase() !== repoFullName.toLowerCase()
+      ) {
+        continue;
+      }
+      numbers.push(parseInt(m.groups!.number, 10));
+    }
+    return numbers;
   }
 
   /**
@@ -286,7 +311,10 @@ export class GithubWebhooksService {
   ): Promise<LinkedIssueOutcome[]> {
     const issueNumbers = [
       ...new Set(
-        this.extractLinkedIssueNumbers(payload.pull_request.body ?? ''),
+        this.extractLinkedIssueNumbers(
+          payload.pull_request.body ?? '',
+          payload.repository.full_name,
+        ),
       ),
     ];
     if (issueNumbers.length === 0) {
@@ -342,7 +370,10 @@ export class GithubWebhooksService {
   ): Promise<LinkedIssueOutcome[]> {
     const issueNumbers = [
       ...new Set(
-        this.extractLinkedIssueNumbers(payload.pull_request.body ?? ''),
+        this.extractLinkedIssueNumbers(
+          payload.pull_request.body ?? '',
+          payload.repository.full_name,
+        ),
       ),
     ];
     if (issueNumbers.length === 0) {


### PR DESCRIPTION
…repo

CLOSING_KEYWORD_RE parsed an optional owner/repo qualifier (e.g. "Fixes some-other-org/some-other-repo#45") but extractLinkedIssueNumbers only ever read the digit group, silently discarding the qualifier. handlePullRequest (and its opened/closed-without-merge siblings) then looked up the number against the webhook's own repository regardless, so a PR body referencing an issue in a completely different repo could incorrectly resolve and mutate a same-numbered issue/bounty in the current repo.

extractLinkedIssueNumbers now takes the webhook's own repository full_name and skips any reference whose qualifier doesn't match it (case-insensitive), instead of resolving it against the wrong repository.

Closes #121
Closes #120
Closes #124
Closes #127