### PR TITLE
feat: add sponsor, bounty, and escrow coverage

### DIFF
--- a/src/bounties/bounties.controller.ts
+++ b/src/bounties/bounties.controller.ts
@@ -13,7 +13,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { BountiesService } from './bounties.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
 import { ClaimBountyDto } from './dto/claim-bounty.dto';
-import { BountyStatus } from '../common/enums';
+import { AssetType, BountyDifficulty, BountyStatus } from '../common/enums';
 import { Idempotent } from '../common/idempotency/idempotent.decorator';
 import { IsStellarAddress } from '../common/validators/stellar-address.validator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -43,8 +43,20 @@ export class BountiesController {
   list(
     @Query('status', new ParseEnumPipe(BountyStatus, { optional: true }))
     status?: BountyStatus,
+    @Query('difficulty', new ParseEnumPipe(BountyDifficulty, { optional: true }))
+    difficulty?: BountyDifficulty,
+    @Query('asset', new ParseEnumPipe(AssetType, { optional: true }))
+    asset?: AssetType,
+    @Query('repositoryId') repositoryId?: string,
+    @Query('primaryLanguage') primaryLanguage?: string,
   ) {
-    return this.bountiesService.list(status);
+    return this.bountiesService.list({
+      status,
+      difficulty,
+      asset,
+      repositoryId,
+      primaryLanguage,
+    });
   }
 
   @Get(':id')

--- a/src/bounties/bounties.service.spec.ts
+++ b/src/bounties/bounties.service.spec.ts
@@ -270,4 +270,46 @@ describe('BountiesService', () => {
       InvalidBountyTransitionError,
     );
   });
+
+  it('lists bounties with repository and language filters', async () => {
+    const qb = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    bountyRepo.createQueryBuilder.mockReturnValue(qb);
+
+    await service.list({
+      status: BountyStatus.OPEN,
+      difficulty: BountyDifficulty.BEGINNER,
+      asset: AssetType.USDC,
+      repositoryId: 'repo-1',
+      primaryLanguage: 'TypeScript',
+    });
+
+    expect(bountyRepo.createQueryBuilder).toHaveBeenCalledWith('bounty');
+    expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('bounty.issue', 'issue');
+    expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
+      'issue.repository',
+      'repository',
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith('bounty.status = :status', {
+      status: BountyStatus.OPEN,
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'bounty.difficulty = :difficulty',
+      { difficulty: BountyDifficulty.BEGINNER },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith('bounty.asset = :asset', {
+      asset: AssetType.USDC,
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'issue.repositoryId = :repositoryId',
+      { repositoryId: 'repo-1' },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'repository.primaryLanguage = :primaryLanguage',
+      { primaryLanguage: 'TypeScript' },
+    );
+  });
 });

--- a/src/bounties/bounties.service.ts
+++ b/src/bounties/bounties.service.ts
@@ -2,10 +2,18 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Bounty, Team, User } from '../common/entities';
-import { BountyStatus } from '../common/enums';
+import { AssetType, BountyDifficulty, BountyStatus } from '../common/enums';
 import { assertTransition } from './bounty-state-machine';
 import { EscrowService } from '../escrow/escrow.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
+
+export interface ListBountiesOptions {
+  status?: BountyStatus;
+  difficulty?: BountyDifficulty;
+  asset?: AssetType;
+  repositoryId?: string;
+  primaryLanguage?: string;
+}
 
 @Injectable()
 export class BountiesService {
@@ -190,7 +198,34 @@ export class BountiesService {
     return overdue.length;
   }
 
-  async list(status?: BountyStatus): Promise<Bounty[]> {
-    return this.bountyRepo.find({ where: status ? { status } : {} });
+  async list(options: ListBountiesOptions = {}): Promise<Bounty[]> {
+    const qb = this.bountyRepo
+      .createQueryBuilder('bounty')
+      .leftJoinAndSelect('bounty.issue', 'issue')
+      .leftJoinAndSelect('issue.repository', 'repository');
+
+    if (options.status) {
+      qb.andWhere('bounty.status = :status', { status: options.status });
+    }
+    if (options.difficulty) {
+      qb.andWhere('bounty.difficulty = :difficulty', {
+        difficulty: options.difficulty,
+      });
+    }
+    if (options.asset) {
+      qb.andWhere('bounty.asset = :asset', { asset: options.asset });
+    }
+    if (options.repositoryId) {
+      qb.andWhere('issue.repositoryId = :repositoryId', {
+        repositoryId: options.repositoryId,
+      });
+    }
+    if (options.primaryLanguage) {
+      qb.andWhere('repository.primaryLanguage = :primaryLanguage', {
+        primaryLanguage: options.primaryLanguage,
+      });
+    }
+
+    return qb.getMany();
   }
 }

--- a/src/escrow/escrow.controller.spec.ts
+++ b/src/escrow/escrow.controller.spec.ts
@@ -92,11 +92,30 @@ describe('EscrowController (#19 metadata leak)', () => {
     expect(JSON.stringify(result)).not.toContain('internal RPC detail');
   });
 
+  it('fund() forwards the DTO to EscrowService', async () => {
+    const dto = {
+      amount: '100',
+      asset: AssetType.USDC,
+      funderAddress: 'GFUNDER',
+      bountyId: 'bounty_1',
+    };
+
+    await controller.fund(dto);
+
+    expect(escrowService.fund).toHaveBeenCalledWith(dto);
+  });
+
   it('findOne() (GET /escrow/:id) never returns metadata to the client', async () => {
     const result = await controller.findOne('esc_1');
 
     expect(result).not.toHaveProperty('metadata');
     expect(JSON.stringify(result)).not.toContain('internal RPC detail');
+  });
+
+  it('findOne() forwards the id to EscrowService', async () => {
+    await controller.findOne('esc_1');
+
+    expect(escrowService.findOne).toHaveBeenCalledWith('esc_1');
   });
 
   it('release() never returns metadata to the client', async () => {
@@ -107,9 +126,40 @@ describe('EscrowController (#19 metadata leak)', () => {
     expect(result).not.toHaveProperty('metadata');
   });
 
+  it('release() forwards the parsed id and DTO fields to EscrowService', async () => {
+    await controller.release('esc_1', {
+      recipientAddress: 'GRECIPIENT',
+      recipientId: 'user_1',
+    });
+
+    expect(escrowService.release).toHaveBeenCalledWith(
+      'esc_1',
+      'GRECIPIENT',
+      'user_1',
+    );
+  });
+
   it('refund() never returns metadata to the client', async () => {
     const result = await controller.refund('esc_1');
 
     expect(result).not.toHaveProperty('metadata');
+  });
+
+  it('refund() forwards the id to EscrowService', async () => {
+    await controller.refund('esc_1');
+
+    expect(escrowService.refund).toHaveBeenCalledWith('esc_1');
+  });
+
+  it('splitRelease() forwards the parsed id and recipients to EscrowService', async () => {
+    await controller.splitRelease('esc_1', {
+      recipients: [
+        { recipientId: 'u1', recipientAddress: 'G1', percentage: 60 },
+      ],
+    });
+
+    expect(escrowService.splitRelease).toHaveBeenCalledWith('esc_1', [
+      { recipientId: 'u1', recipientAddress: 'G1', percentage: 60 },
+    ]);
   });
 });

--- a/src/sponsors/sponsors.controller.ts
+++ b/src/sponsors/sponsors.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   ParseUUIDPipe,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
@@ -31,9 +32,14 @@ export class SponsorsController {
   dashboard(
     @Param('id', new ParseUUIDPipe()) id: string,
     @CurrentUser() user: AuthenticatedUser,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
   ) {
     this.assertOwnsSponsor(user, id);
-    return this.sponsorsService.dashboard(id);
+    return this.sponsorsService.dashboard(id, {
+      limit: limit ? Number(limit) : undefined,
+      offset: offset ? Number(offset) : undefined,
+    });
   }
 
   @ApiBearerAuth()

--- a/src/sponsors/sponsors.service.spec.ts
+++ b/src/sponsors/sponsors.service.spec.ts
@@ -2,7 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SponsorsService } from './sponsors.service';
 import { Bounty, Escrow, Milestone, Payment } from '../common/entities';
-import { EscrowStatus, PaymentStatus } from '../common/enums';
+import {
+  BountyStatus,
+  EscrowStatus,
+  MilestoneStatus,
+  PaymentStatus,
+} from '../common/enums';
 
 /**
  * Minimal fluent mock of TypeORM's QueryBuilder: every chainable method
@@ -17,6 +22,7 @@ function createMockQueryBuilder(result: { raw?: unknown; many?: unknown[] }) {
     innerJoin: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
     getRawOne: jest.fn().mockResolvedValue(result.raw),
     getMany: jest.fn().mockResolvedValue(result.many ?? []),
   };
@@ -138,6 +144,109 @@ describe('SponsorsService', () => {
         'escrow.sponsorId = :sponsorId',
         { sponsorId: 'sponsor-1' },
       );
+    });
+
+    it('uses the default 20-payment window when no paging params are provided', async () => {
+      bountyRepo.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({ many: [] }),
+      );
+      escrowRepo.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({ raw: { total: '0' } }),
+      );
+      const paymentsQb = createMockQueryBuilder({ many: [] });
+      paymentRepo.createQueryBuilder.mockReturnValue(paymentsQb);
+
+      await service.dashboard('sponsor-1');
+
+      expect(paymentsQb.take).toHaveBeenCalledWith(20);
+      expect(paymentsQb.skip).toHaveBeenCalledWith(0);
+    });
+
+    it('passes through pagination params to recentPayments', async () => {
+      bountyRepo.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({ many: [] }),
+      );
+      escrowRepo.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({ raw: { total: '0' } }),
+      );
+      const paymentsQb = createMockQueryBuilder({ many: [] });
+      paymentRepo.createQueryBuilder.mockReturnValue(paymentsQb);
+
+      await service.dashboard('sponsor-1', { limit: 5, offset: 40 });
+
+      expect(paymentsQb.take).toHaveBeenCalledWith(5);
+      expect(paymentsQb.skip).toHaveBeenCalledWith(40);
+    });
+  });
+
+  describe('activeBounties', () => {
+    it('excludes terminal bounty statuses', async () => {
+      const qb = createMockQueryBuilder({ many: [] });
+      bountyRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.activeBounties('sponsor-1');
+
+      expect(bountyRepo.createQueryBuilder).toHaveBeenCalledWith('bounty');
+      expect(qb.where).toHaveBeenCalledWith('bounty.sponsorId = :sponsorId', {
+        sponsorId: 'sponsor-1',
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'bounty.status NOT IN (:...terminal)',
+        {
+          terminal: [
+            BountyStatus.PAID,
+            BountyStatus.REFUNDED,
+            BountyStatus.EXPIRED,
+          ],
+        },
+      );
+    });
+  });
+
+  describe('activeMilestones', () => {
+    it('matches funded or in-progress milestones for the sponsor', async () => {
+      const milestones = [{ id: 'm1' }, { id: 'm2' }];
+      milestoneRepo.find.mockResolvedValue(milestones);
+
+      const result = await service.activeMilestones('sponsor-1');
+
+      expect(milestoneRepo.find).toHaveBeenCalledWith({
+        where: [
+          { sponsorId: 'sponsor-1', status: MilestoneStatus.FUNDED },
+          { sponsorId: 'sponsor-1', status: MilestoneStatus.IN_PROGRESS },
+        ],
+      });
+      expect(result).toBe(milestones);
+    });
+  });
+
+  describe('milestoneProgress', () => {
+    it('computes distributed / budget for each milestone', async () => {
+      milestoneRepo.find.mockResolvedValue([
+        { id: 'm1', title: 'One', budget: '100.0000000', distributed: '25.0000000' },
+      ]);
+
+      await expect(service.milestoneProgress('sponsor-1')).resolves.toEqual([
+        {
+          milestoneId: 'm1',
+          title: 'One',
+          progress: 0.25,
+        },
+      ]);
+    });
+
+    it('guards against division by zero when budget is zero', async () => {
+      milestoneRepo.find.mockResolvedValue([
+        { id: 'm1', title: 'Zero', budget: '0', distributed: '50.0000000' },
+      ]);
+
+      await expect(service.milestoneProgress('sponsor-1')).resolves.toEqual([
+        {
+          milestoneId: 'm1',
+          title: 'Zero',
+          progress: 0,
+        },
+      ]);
     });
   });
 });

--- a/src/sponsors/sponsors.service.ts
+++ b/src/sponsors/sponsors.service.ts
@@ -17,6 +17,11 @@ export interface SponsorDashboard {
   recentPayments: Payment[];
 }
 
+export interface SponsorDashboardOptions {
+  limit?: number;
+  offset?: number;
+}
+
 @Injectable()
 export class SponsorsService {
   constructor(
@@ -107,7 +112,10 @@ export class SponsorsService {
     }));
   }
 
-  async dashboard(sponsorId: string): Promise<SponsorDashboard> {
+  async dashboard(
+    sponsorId: string,
+    options: SponsorDashboardOptions = {},
+  ): Promise<SponsorDashboard> {
     const [activeBounties, totalSpent, budgetLocked, activeMilestones] =
       await Promise.all([
         this.activeBounties(sponsorId),
@@ -126,7 +134,8 @@ export class SponsorsService {
       .innerJoin('payment.escrow', 'escrow')
       .where('escrow.sponsorId = :sponsorId', { sponsorId })
       .orderBy('payment.createdAt', 'DESC')
-      .take(20)
+      .take(options.limit ?? 20)
+      .skip(options.offset ?? 0)
       .getMany();
 
     return {

--- a/test/escrow-idempotency.e2e-spec.ts
+++ b/test/escrow-idempotency.e2e-spec.ts
@@ -134,19 +134,22 @@ describe('Escrow idempotency: cross-resource key reuse (#54)', () => {
     );
 
     const releaseA = await request(app.getHttpServer())
-      .post('/escrow/escrow-A/release')
+      .post('/escrow/11111111-1111-4111-8111-111111111111/release')
       .set('Idempotency-Key', IDEMPOTENCY_KEY)
       .send({ recipientAddress: 'GADDRESSA' })
       .expect(201);
 
-    expect(releaseA.body).toMatchObject({ id: 'escrow-A', status: 'released' });
+    expect(releaseA.body).toMatchObject({
+      id: '11111111-1111-4111-8111-111111111111',
+      status: 'released',
+    });
     expect(escrowService.release).toHaveBeenCalledTimes(1);
 
     // Same Idempotency-Key, but a genuinely different resource (#54's
     // reproduction) — must not replay escrow A's cached response as if it
     // were escrow B's.
     const releaseB = await request(app.getHttpServer())
-      .post('/escrow/escrow-B/release')
+      .post('/escrow/22222222-2222-4222-8222-222222222222/release')
       .set('Idempotency-Key', IDEMPOTENCY_KEY)
       .send({ recipientAddress: 'GADDRESSB' })
       .expect(422);
@@ -160,10 +163,21 @@ describe('Escrow idempotency: cross-resource key reuse (#54)', () => {
     // executing.
     expect(escrowService.release).toHaveBeenCalledTimes(1);
     expect(escrowService.release).not.toHaveBeenCalledWith(
-      'escrow-B',
+      '22222222-2222-4222-8222-222222222222',
       expect.anything(),
       expect.anything(),
     );
+  });
+
+  it('requires Idempotency-Key on an @Idempotent route through the real Nest HTTP stack', async () => {
+    await request(app.getHttpServer())
+      .post('/escrow/44444444-4444-4444-8444-444444444444/release')
+      .send({ recipientAddress: 'GADDRESSD' })
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.message).toMatch(/Idempotency-Key/i);
+      });
+    expect(escrowService.release).not.toHaveBeenCalled();
   });
 
   it('still replays correctly when the same key is retried against the same escrow and body', async () => {
@@ -174,13 +188,13 @@ describe('Escrow idempotency: cross-resource key reuse (#54)', () => {
     });
 
     const first = await request(app.getHttpServer())
-      .post('/escrow/escrow-C/release')
+      .post('/escrow/33333333-3333-4333-8333-333333333333/release')
       .set('Idempotency-Key', key)
       .send({ recipientAddress: 'GADDRESSC' })
       .expect(201);
 
     const retry = await request(app.getHttpServer())
-      .post('/escrow/escrow-C/release')
+      .post('/escrow/33333333-3333-4333-8333-333333333333/release')
       .set('Idempotency-Key', key)
       .send({ recipientAddress: 'GADDRESSC' })
       .expect(201);


### PR DESCRIPTION
Adds coverage for sponsors, bounties, and escrow controller/idempotency behavior, and exposes pagination/filtering where the API previously truncated or ignored useful data.

Closes #144
Closes #143
Closes #142
Closes #141