### PR TITLE
fix: cap syncIssues pagination and add baseline spec files

### DIFF
--- a/src/analytics/analytics.service.spec.ts
+++ b/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AnalyticsService } from './analytics.service';
+import { Bounty, Issue, Repository as RepositoryEntity } from '../common/entities';
+import { BountyStatus } from '../common/enums';
+import * as statsUtil from '../common/stats/contributor-stats.util';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  const mockBountyRepo = {
+    find: jest.fn(),
+    count: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const mockIssueRepo = {
+    find: jest.fn(),
+  };
+
+  const mockRepositoryRepo = {
+    count: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        { provide: getRepositoryToken(Bounty), useValue: mockBountyRepo },
+        { provide: getRepositoryToken(Issue), useValue: mockIssueRepo },
+        { provide: getRepositoryToken(RepositoryEntity), useValue: mockRepositoryRepo },
+      ],
+    }).compile();
+
+    service = module.get<AnalyticsService>(AnalyticsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle empty input correctly (zero bounties)', async () => {
+    mockBountyRepo.find.mockResolvedValue([]);
+    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+      mergedCount: 0,
+      completionRate: 0,
+      avgReviewTimeHours: 0,
+      languages: {},
+      orgs: [],
+    });
+
+    const result = await service.forContributor('user-1');
+    expect(result.lifetimeEarnings).toBe(0);
+    expect(result.repoCount).toBe(0);
+    expect(result.orgCount).toBe(0);
+    expect(result.mergeRate).toBe(0);
+    expect(result.avgReviewTimeHours).toBe(0);
+    expect(result.heatmap).toEqual([]);
+    expect(result.topClients).toEqual([]);
+  });
+
+  it('should compute heatmap date-bucketing and merge-rate correctly', async () => {
+    mockBountyRepo.find.mockResolvedValue([
+      { id: 'b1', issueId: 'i1', amount: '100', status: BountyStatus.PAID, paidAt: new Date('2023-01-01T10:00:00Z'), sponsorId: 'client-A' },
+      { id: 'b2', issueId: 'i2', amount: '200', status: BountyStatus.PAID, paidAt: new Date('2023-01-01T15:00:00Z'), sponsorId: 'client-B' },
+      { id: 'b3', issueId: 'i3', amount: '50', status: BountyStatus.PAID, paidAt: new Date('2023-01-02T10:00:00Z'), sponsorId: 'client-A' },
+    ]);
+    mockIssueRepo.find.mockResolvedValue([
+      { id: 'i1', repositoryId: 'r1' },
+      { id: 'i2', repositoryId: 'r2' },
+      { id: 'i3', repositoryId: 'r1' },
+    ]);
+    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+      mergedCount: 3,
+      completionRate: 100,
+      avgReviewTimeHours: 2,
+      languages: { TypeScript: 3 },
+      orgs: ['org1'],
+    });
+
+    const result = await service.forContributor('user-1');
+    expect(result.mergeRate).toBe(100);
+    expect(result.heatmap).toEqual([
+      { date: '2023-01-01', count: 2 },
+      { date: '2023-01-02', count: 1 },
+    ]);
+    // Sorted by total paid (B=200, A=150)
+    expect(result.topClients).toEqual([
+      { sponsorId: 'client-B', totalPaid: 200 },
+      { sponsorId: 'client-A', totalPaid: 150 },
+    ]);
+  });
+});

--- a/src/github/github-sync.service.ts
+++ b/src/github/github-sync.service.ts
@@ -79,8 +79,7 @@ export class GithubSyncService {
     private readonly issueRepo: TypeOrmRepository<Issue>,
   ) {}
 
-  /** Imports (or refreshes) a single repository and all of its open+closed issues. */
-  async syncRepository(owner: string, repo: string): Promise<Repository> {
+  async syncRepository(owner: string, repo: string, page = 1): Promise<{ repository: Repository, synced: number, nextPage?: number }> {
     const repoResponse = await this.octokit.repos.get({ owner, repo });
     this.logRateLimitFromHeaders(
       `before ${owner}/${repo}`,
@@ -111,8 +110,8 @@ export class GithubSyncService {
       : this.repositoryRepo.create(attrs);
     repository = await this.repositoryRepo.save(repository);
 
-    await this.syncIssues(repository, owner, repo);
-    return repository;
+    const result = await this.syncIssues(repository, owner, repo, page);
+    return { repository, synced: result.saved.length, nextPage: result.nextPage };
   }
 
   /**
@@ -126,42 +125,46 @@ export class GithubSyncService {
     repository: Repository,
     owner: string,
     repo: string,
-  ): Promise<Issue[]> {
+    page = 1,
+  ): Promise<{ saved: Issue[], nextPage?: number }> {
     const saved: Issue[] = [];
-    let pagesFetched = 0;
 
     try {
-      for await (const response of this.octokit.paginate.iterator(
-        this.octokit.issues.listForRepo,
-        { owner, repo, state: 'all', per_page: 100 },
-      )) {
-        pagesFetched += 1;
-        for (const raw of response.data as RawGithubIssue[]) {
-          // Octokit returns PRs in the issues list too; skip those.
-          if (raw.pull_request) continue;
+      const response = await this.octokit.issues.listForRepo({
+        owner,
+        repo,
+        state: 'all',
+        per_page: 100,
+        page,
+      });
 
-          const { issue, applied } = await this.upsertIssueRecord(
-            repository.id,
-            raw,
-          );
-          if (applied) saved.push(issue);
-        }
-        this.logRateLimitFromHeaders(
-          `after ${owner}/${repo} (page ${pagesFetched})`,
-          response.headers,
+      for (const raw of response.data as RawGithubIssue[]) {
+        // Octokit returns PRs in the issues list too; skip those.
+        if (raw.pull_request) continue;
+
+        const { issue, applied } = await this.upsertIssueRecord(
+          repository.id,
+          raw,
         );
+        if (applied) saved.push(issue);
       }
+      this.logRateLimitFromHeaders(
+        `after ${owner}/${repo} (page ${page})`,
+        response.headers,
+      );
+
+      const hasNextPage = response.headers.link?.includes('rel="next"');
+
+      this.logger.log(`Synced ${saved.length} issues for ${owner}/${repo} (page ${page})`);
+      return { saved, nextPage: hasNextPage ? page + 1 : undefined };
     } catch (err) {
       const cause = err as Error;
       this.logger.error(
-        `GitHub sync interrupted for ${owner}/${repo} after ${pagesFetched} ` +
-          `page(s) / ${saved.length} issue(s) persisted: ${cause.message}`,
+        `GitHub sync interrupted for ${owner}/${repo} at page ${page} ` +
+          `/ ${saved.length} issue(s) persisted: ${cause.message}`,
       );
       throw new GithubSyncInterruptedError(owner, repo, saved.length, cause);
     }
-
-    this.logger.log(`Synced ${saved.length} issues for ${owner}/${repo}`);
-    return saved;
   }
 
   /**

--- a/src/github/github.controller.ts
+++ b/src/github/github.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Param, Post } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, DefaultValuePipe, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { ApiTags, ApiQuery } from '@nestjs/swagger';
 import { GithubSyncService } from './github-sync.service';
 
 @ApiTags('github')
@@ -8,7 +8,12 @@ export class GithubController {
   constructor(private readonly syncService: GithubSyncService) {}
 
   @Post('sync/:owner/:repo')
-  sync(@Param('owner') owner: string, @Param('repo') repo: string) {
-    return this.syncService.syncRepository(owner, repo);
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  sync(
+    @Param('owner') owner: string,
+    @Param('repo') repo: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+  ) {
+    return this.syncService.syncRepository(owner, repo, page);
   }
 }

--- a/src/reputation/reputation.service.spec.ts
+++ b/src/reputation/reputation.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ReputationService } from './reputation.service';
+import { Bounty, Issue, ReputationSnapshot } from '../common/entities';
+import { BountyStatus } from '../common/enums';
+import * as statsUtil from '../common/stats/contributor-stats.util';
+
+describe('ReputationService', () => {
+  let service: ReputationService;
+
+  const mockBountyRepo = {
+    find: jest.fn(),
+  };
+
+  const mockIssueRepo = {
+    find: jest.fn(),
+  };
+
+  const mockSnapshotRepo = {
+    create: jest.fn((dto) => dto),
+    save: jest.fn((entity) => Promise.resolve({ id: 'snap-1', ...entity })),
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReputationService,
+        { provide: getRepositoryToken(Bounty), useValue: mockBountyRepo },
+        { provide: getRepositoryToken(Issue), useValue: mockIssueRepo },
+        { provide: getRepositoryToken(ReputationSnapshot), useValue: mockSnapshotRepo },
+      ],
+    }).compile();
+
+    service = module.get<ReputationService>(ReputationService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle empty input correctly (zero bounties)', async () => {
+    mockBountyRepo.find.mockResolvedValue([]);
+    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+      mergedCount: 0,
+      completionRate: 0,
+      avgReviewTimeHours: 0,
+      languages: {},
+      orgs: [],
+    });
+
+    const result = await service.computeAndSave('user-1');
+    expect(result.totalEarnings).toBe('0.0000000');
+    expect(result.mergedPrCount).toBe(0);
+    expect(result.openBountiesClaimed).toBe(0);
+    expect(result.completionRate).toBe('0.00');
+    expect(result.onTimeDeliveryPercentage).toBe('0.00');
+  });
+
+  it('should compute completion-rate and on-time-delivery math correctly', async () => {
+    mockBountyRepo.find.mockResolvedValue([
+      { status: BountyStatus.PAID, amount: '100', deadline: new Date('2023-01-02'), mergedAt: new Date('2023-01-01') },
+      { status: BountyStatus.MERGED, amount: '0', deadline: new Date('2023-01-01'), mergedAt: new Date('2023-01-02') }, // Late
+      { status: BountyStatus.CLAIMED, amount: '50' },
+    ]);
+    mockIssueRepo.find.mockResolvedValue([]);
+    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+      mergedCount: 2,
+      completionRate: 66.67,
+      avgReviewTimeHours: 2.5,
+      languages: {},
+      orgs: [],
+    });
+
+    const result = await service.computeAndSave('user-1');
+    expect(result.totalEarnings).toBe('100.0000000'); // only PAID
+    expect(result.openBountiesClaimed).toBe(1); // CLAIMED
+    expect(result.completionRate).toBe('66.67');
+    expect(result.onTimeDeliveryPercentage).toBe('50.00'); // 1 on-time out of 2 merged
+  });
+});


### PR DESCRIPTION
## Summary
Fixes issues with github issue syncing timeouts and adds missing test coverage for analytics and reputation services.

## Changes
- Capped `syncIssues` to single-page processing using a page parameter and resumable cursor (`nextPage`).
- Updated `GithubController` to accept a `page` query parameter for sync continuation.
- Added baseline test coverage for `AnalyticsService` covering empty input, heatmap date-bucketing, and client sorting.
- Added baseline test coverage for `ReputationService` covering empty input, completion-rate calculation, and on-time-delivery logic.

## Issues
Resolves #140
Resolves #129
Resolves #130
Resolves #139

## Verification
- Manual code review completed.
- `cargo build` was not run.
- `cargo test` was not run.
- No snapshots were committed.
