### PR TITLE
fix: require maintainer auth on POST /github/sync/:owner/:repo

### DIFF
--- a/src/github/github.controller.ts
+++ b/src/github/github.controller.ts
@@ -1,14 +1,32 @@
-import { Controller, DefaultValuePipe, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
-import { ApiTags, ApiQuery } from '@nestjs/swagger';
+import {
+  Controller,
+  DefaultValuePipe,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { GithubSyncService } from './github-sync.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../common/enums';
 
 @ApiTags('github')
 @Controller('github')
 export class GithubController {
   constructor(private readonly syncService: GithubSyncService) {}
 
+  // #62 — this endpoint triggers a full repository sync (writes + GitHub API
+  // calls under this server's credentials) and was completely unauthenticated.
+  // Restricted to authenticated maintainers.
   @Post('sync/:owner/:repo')
+  @ApiBearerAuth()
   @ApiQuery({ name: 'page', required: false, type: Number })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.MAINTAINER)
   sync(
     @Param('owner') owner: string,
     @Param('repo') repo: string,


### PR DESCRIPTION
## Summary

`POST /github/sync/:owner/:repo` triggered a full repository sync — DB writes plus GitHub API calls under the server's own credentials — with zero authentication, letting anyone on the internet trigger it. Added `JwtAuthGuard` + `RolesGuard` restricted to `UserRole.MAINTAINER`, matching the guard pattern already used on other privileged endpoints (e.g. `maintenance-pool.controller.ts`).

Closes #62
Closes #6
Closes #17
Closes #25