### PR TITLE
fix: compare escrow release amounts in stroops instead of float

### DIFF
--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -254,12 +254,15 @@ export class EscrowService {
     const existingPayments = await this.paymentRepo.find({
       where: { escrowId: escrow.id },
     });
-    const releasedSoFar = existingPayments.reduce(
-      (sum, p) => sum + Number(p.amount),
-      0,
+    // Compare in stroops (BigInt) rather than Number to avoid IEEE-754
+    // precision loss / epsilon-fudge factors on financial amounts (#5).
+    const releasedSoFarStroops = existingPayments.reduce(
+      (sum, p) => sum + amountToStroops(p.amount),
+      0n,
     );
-    const requested = Number(amount);
-    if (releasedSoFar + requested > Number(escrow.amount) + 1e-7) {
+    const requestedStroops = amountToStroops(amount);
+    const escrowStroops = amountToStroops(escrow.amount);
+    if (releasedSoFarStroops + requestedStroops > escrowStroops) {
       throw new BadRequestException(
         `Partial release of ${amount} would exceed remaining escrow balance`,
       );
@@ -309,7 +312,7 @@ export class EscrowService {
         }),
       );
 
-      if (releasedSoFar + requested >= Number(escrow.amount) - 1e-7) {
+      if (releasedSoFarStroops + requestedStroops >= escrowStroops) {
         escrow.status = EscrowStatus.RELEASED;
         escrow.releaseTxHash = result.txHash;
         escrow.releasedAt = new Date();


### PR DESCRIPTION
## Summary

`EscrowService.releasePartial` compared cumulative released amount against the escrow total using `Number(...)` on decimal-string amounts, guarded by an `1e-7` epsilon fudge factor to paper over IEEE-754 precision loss — the classic symptom of financial math done in floats instead of an exact integer type.

**Fix:** reuse the existing `amountToStroops()` helper (already used elsewhere in this service for on-chain calls) to convert `escrow.amount`, `amount`, and each payment's `amount` to `bigint` stroops before comparing. This removes the epsilon hack entirely — bigint comparison is exact, so there's no rounding-tolerance question left to get wrong.

Closes #5
Closes #46
Closes #56
Closes #10