### PR TITLE
fix: add BytesN<32> encoding path to SorobanClientService.toScVal

### DIFF
--- a/src/escrow/soroban-client.service.spec.ts
+++ b/src/escrow/soroban-client.service.spec.ts
@@ -285,6 +285,30 @@ describe('SorobanClientService', () => {
       expect(nativeToScValMock).not.toHaveBeenCalled();
     });
 
+    it('encodes a Buffer as BytesN bytes (#45)', () => {
+      const hash = Buffer.from('a'.repeat(32));
+
+      const encoded = (
+        service as unknown as { toScVal(v: unknown): unknown }
+      ).toScVal(hash);
+
+      expect(nativeToScValMock).toHaveBeenCalledWith(hash, { type: 'bytes' });
+      expect(encoded).toEqual(hash);
+    });
+
+    it('encodes a Uint8Array as BytesN bytes (#45)', () => {
+      const hash = new Uint8Array(32).fill(7);
+
+      const encoded = (
+        service as unknown as { toScVal(v: unknown): unknown }
+      ).toScVal(hash);
+
+      expect(nativeToScValMock).toHaveBeenCalledWith(Buffer.from(hash), {
+        type: 'bytes',
+      });
+      expect(encoded).toEqual(Buffer.from(hash));
+    });
+
     it('encodes bigints as i128', () => {
       const encoded = (
         service as unknown as { toScVal(v: unknown): unknown }

--- a/src/escrow/soroban-client.service.ts
+++ b/src/escrow/soroban-client.service.ts
@@ -219,6 +219,14 @@ export class SorobanClientService {
   }
 
   private toScVal(value: unknown): unknown {
+    if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+      // BytesN<32> arguments (metadata hashes, description hashes, etc.)
+      // arrive as raw bytes, not strings — without this branch they fell
+      // through to the generic nativeToScVal(value) call below with no
+      // `bytes` type hint, which does not reliably encode a Buffer/
+      // Uint8Array as ScVal bytes (#45).
+      return nativeToScVal(Buffer.from(value), { type: 'bytes' });
+    }
     if (Array.isArray(value)) {
       // Vec<...> arguments, including the Vec<(Address, u32)> recipients
       // list escrow::release takes. A [address, basisPoints] pair encodes


### PR DESCRIPTION
## Summary

`SorobanClientService.toScVal` had no explicit branch for `Buffer`/`Uint8Array` values — the actual runtime shape of a `BytesN<32>` contract argument (metadata hashes, description hashes). They fell through to a bare `nativeToScVal(value)` call with no `bytes` type hint, unlike the existing explicit `i128`/`u32` handling elsewhere in the same function.

Adds a `Buffer.isBuffer(value) || value instanceof Uint8Array` check that encodes via `nativeToScVal(Buffer.from(value), { type: 'bytes' })`, plus two tests covering `Buffer` and `Uint8Array` inputs.

Closes #14
Closes #45
Closes #48
Closes #20