### PR TITLE
fix: stop .dockerignore excluding nest-cli.json/tsconfig files needed by builder stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,11 +30,11 @@ docker-compose.yml
 .DS_Store
 Thumbs.db
 
-# Documentation and configs not needed in production container
+# Documentation and lint/format configs not needed in production container.
+# nest-cli.json, tsconfig.json, and tsconfig.build.json are NOT listed here —
+# the builder stage's `COPY . .` needs them in the build context for
+# `npm run build` (nest build) to succeed; excluding them broke the image build.
 README.md
-nest-cli.json
-tsconfig.json
-tsconfig.build.json
 eslint.config.mjs
 .prettierrc
 test/


### PR DESCRIPTION
`.dockerignore` excluded `nest-cli.json`, `tsconfig.json`, and `tsconfig.build.json` under the assumption they're only needed at dev time. But the Dockerfile's `builder` stage does `COPY . .` then `npm run build` (`nest build`), which requires all three files to be present in the build context — excluding them broke the production image build. Removed them from `.dockerignore`; they're still absent from the final `runner` stage since only `dist/` is copied out of `builder`.

Closes #176
Closes #175
Closes #177
Closes #8