### PR TITLE
fix: Bounty.issue FK from CASCADE to RESTRICT

### DIFF
--- a/src/common/entities/bounty.entity.ts
+++ b/src/common/entities/bounty.entity.ts
@@ -20,7 +20,12 @@ export class Bounty {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @OneToOne(() => Issue, (issue) => issue.bounty, { onDelete: 'CASCADE' })
+  // RESTRICT, not CASCADE: a Bounty is a financial record (it may have a
+  // funded Escrow attached — see the `escrow` relation below), so deleting
+  // its parent Issue must never silently delete it too. Matches the
+  // RESTRICT/SET NULL convention used by every other financial relation in
+  // this file and in #27's EscrowFkIntegrityAndSponsorId migration. See #53.
+  @OneToOne(() => Issue, (issue) => issue.bounty, { onDelete: 'RESTRICT' })
   @JoinColumn()
   issue: Issue;
 

--- a/src/database/migrations/1785000000000-BountyIssueFkRestrict.ts
+++ b/src/database/migrations/1785000000000-BountyIssueFkRestrict.ts
@@ -1,0 +1,78 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Fixes #53: `bounties.issueId` FK was `ON DELETE CASCADE`, unlike every
+ * other financial relation touching a Bounty (sponsor/claimedBy/team use
+ * SET NULL; escrows.bountyId and payments.escrowId use SET NULL/RESTRICT —
+ * see #27's EscrowFkIntegrityAndSponsorId migration). Deleting an Issue
+ * must never silently delete the Bounty record, which may reference a
+ * funded Escrow. Re-points the FK to RESTRICT — `issueId` is NOT NULL, so
+ * SET NULL isn't a valid option here.
+ */
+export class BountyIssueFkRestrict1785000000000 implements MigrationInterface {
+  name = 'BountyIssueFkRestrict1785000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.replaceForeignKeyOnDelete(
+      queryRunner,
+      'bounties',
+      'issueId',
+      'issues',
+      'RESTRICT',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.replaceForeignKeyOnDelete(
+      queryRunner,
+      'bounties',
+      'issueId',
+      'issues',
+      'CASCADE',
+    );
+  }
+
+  /**
+   * Finds the existing single-column foreign key from `table.column` and
+   * replaces its ON DELETE action in place, preserving whatever name
+   * `synchronize` (or a previous migration) originally gave it — this
+   * avoids hardcoding TypeORM's auto-generated constraint name, which is a
+   * content hash we can't reliably predict across environments.
+   */
+  private async replaceForeignKeyOnDelete(
+    queryRunner: QueryRunner,
+    table: string,
+    column: string,
+    refTable: string,
+    onDelete: 'SET NULL' | 'CASCADE' | 'RESTRICT',
+  ): Promise<void> {
+    const rows = (await queryRunner.query(
+      `
+      SELECT con.conname
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid = con.conrelid
+      JOIN pg_attribute att
+        ON att.attrelid = con.conrelid AND att.attnum = ANY(con.conkey)
+      WHERE con.contype = 'f'
+        AND rel.relname = $1
+        AND att.attname = $2
+      `,
+      [table, column],
+    )) as Array<{ conname: string }>;
+
+    if (rows.length === 0) {
+      // No pre-existing FK to replace (e.g. a database that never ran
+      // `synchronize`) — the entity decorator already declares the correct
+      // ON DELETE action, so there's nothing to fix up here.
+      return;
+    }
+
+    const { conname } = rows[0];
+    await queryRunner.query(
+      `ALTER TABLE "${table}" DROP CONSTRAINT "${conname}"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${table}" ADD CONSTRAINT "${conname}" FOREIGN KEY ("${column}") REFERENCES "${refTable}"("id") ON DELETE ${onDelete}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

`bounties.issueId`'s foreign key was `ON DELETE CASCADE` — the only `CASCADE` among Bounty's relations. Every other one (`sponsor`, `claimedBy`, `team`) uses `SET NULL`, and #27's `EscrowFkIntegrityAndSponsorId` migration already established the convention that financial-adjacent rows (escrows, payments) must never cascade-delete — a Bounty may reference a funded `Escrow`, so deleting its parent `Issue` must not silently delete it too.

## Changes
- `bounty.entity.ts`: `issue` relation `onDelete` changed `CASCADE` → `RESTRICT` (`issueId` is `NOT NULL`, so `SET NULL` isn't valid here — `RESTRICT` mirrors the `payments.escrowId` pattern from #27)
- New migration `BountyIssueFkRestrict1785000000000`: re-points the existing FK constraint in place, reusing the same `replaceForeignKeyOnDelete` helper pattern from #27's migration (looks up the constraint name via `pg_constraint` rather than hardcoding it)

Closes #53
Closes #21
Closes #52
Closes #23