### PR TITLE
fix(milestones): reject attaching an issue from a different repository

### DIFF
--- a/src/milestones/milestones.service.spec.ts
+++ b/src/milestones/milestones.service.spec.ts
@@ -130,12 +130,17 @@ describe('MilestonesService', () => {
   });
 
   describe('addIssue', () => {
-    it('attaches an issue to an OPEN milestone', async () => {
+    it('attaches an issue to an OPEN milestone in the same repository', async () => {
       milestoneRepo.findOne.mockResolvedValue({
         id: 'm1',
         status: MilestoneStatus.OPEN,
+        repositoryId: 'repo-a',
       });
-      issueRepo.findOne.mockResolvedValue({ id: 'i1', state: 'open' });
+      issueRepo.findOne.mockResolvedValue({
+        id: 'i1',
+        state: 'open',
+        repositoryId: 'repo-a',
+      });
 
       const issue = await service.addIssue('m1', 'i1');
 
@@ -145,28 +150,56 @@ describe('MilestonesService', () => {
       );
     });
 
-    it('attaches an issue to a FUNDED milestone', async () => {
+    it('attaches an issue to a FUNDED milestone in the same repository', async () => {
       milestoneRepo.findOne.mockResolvedValue({
         id: 'm1',
         status: MilestoneStatus.FUNDED,
+        repositoryId: 'repo-a',
       });
-      issueRepo.findOne.mockResolvedValue({ id: 'i1', state: 'open' });
+      issueRepo.findOne.mockResolvedValue({
+        id: 'i1',
+        state: 'open',
+        repositoryId: 'repo-a',
+      });
 
       const issue = await service.addIssue('m1', 'i1');
 
       expect(issue.milestoneId).toBe('m1');
     });
 
-    it('attaches an issue to an IN_PROGRESS milestone', async () => {
+    it('attaches an issue to an IN_PROGRESS milestone in the same repository', async () => {
       milestoneRepo.findOne.mockResolvedValue({
         id: 'm1',
         status: MilestoneStatus.IN_PROGRESS,
+        repositoryId: 'repo-a',
       });
-      issueRepo.findOne.mockResolvedValue({ id: 'i1', state: 'open' });
+      issueRepo.findOne.mockResolvedValue({
+        id: 'i1',
+        state: 'open',
+        repositoryId: 'repo-a',
+      });
 
       const issue = await service.addIssue('m1', 'i1');
 
       expect(issue.milestoneId).toBe('m1');
+    });
+
+    it('rejects attaching an issue from a different repository than the milestone', async () => {
+      milestoneRepo.findOne.mockResolvedValue({
+        id: 'm1',
+        status: MilestoneStatus.OPEN,
+        repositoryId: 'repo-a',
+      });
+      issueRepo.findOne.mockResolvedValue({
+        id: 'i1',
+        state: 'open',
+        repositoryId: 'repo-b',
+      });
+
+      await expect(service.addIssue('m1', 'i1')).rejects.toThrow(
+        'Issue i1 belongs to repository repo-b, but milestone m1 is scoped to repository repo-a',
+      );
+      expect(issueRepo.save).not.toHaveBeenCalled();
     });
 
     it('rejects attaching an issue to a COMPLETED milestone', async () => {

--- a/src/milestones/milestones.service.ts
+++ b/src/milestones/milestones.service.ts
@@ -67,7 +67,16 @@ export class MilestonesService {
     return this.milestoneRepo.save(milestone);
   }
 
-  /** Attaches an already-tracked issue to this milestone. */
+  /**
+   * Attaches an already-tracked issue to this milestone.
+   *
+   * A milestone is scoped to a single repository (`repositoryId`, required
+   * at creation); its budget is split proportionally across whatever's
+   * attached in `resolveIssue`, with no per-issue repository check there
+   * either. Rejecting a repository mismatch here, before attachment, is
+   * this method's only opportunity to keep that budget scoped to the work
+   * it was actually funded for (#59).
+   */
   async addIssue(milestoneId: string, issueId: string): Promise<Issue> {
     const milestone = await this.findOne(milestoneId);
     if (
@@ -81,6 +90,12 @@ export class MilestonesService {
     }
     const issue = await this.issueRepo.findOne({ where: { id: issueId } });
     if (!issue) throw new NotFoundException(`Issue ${issueId} not found`);
+    if (issue.repositoryId !== milestone.repositoryId) {
+      throw new BadRequestException(
+        `Issue ${issueId} belongs to repository ${issue.repositoryId}, ` +
+          `but milestone ${milestoneId} is scoped to repository ${milestone.repositoryId}`,
+      );
+    }
     issue.milestoneId = milestone.id;
     return this.issueRepo.save(issue);
   }


### PR DESCRIPTION
## What changed
`MilestonesService.addIssue` now rejects attaching an issue whose `repositoryId` doesn't match the target milestone's `repositoryId`, throwing a `BadRequestException` naming both repository IDs.

## Why
`resolveIssue` splits a milestone's remaining budget evenly across whatever issues are currently attached, with no per-issue repository check. Since `addIssue` never validated the issue and milestone belonged to the same repository, a cross-repository issue (copy-pasted ID, client-side picker bug, wrong UUID) could get attached and silently dilute a sponsor's repository-scoped budget toward unrelated work.

## Note on scope
The issue also flagged `POST /milestones/:id/issues/:issueId` as unguarded. In the current code that route already carries `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles(UserRole.MAINTAINER)` — verified in `milestones.controller.ts`. That part doesn't apply as filed, so it's not touched here.

## How verified
- Added a test asserting cross-repo attachment is rejected with the exact error message, and `issueRepo.save` is never called.
- Updated the 3 existing same-repository attachment tests to set matching `repositoryId`s explicitly.
- `npx jest milestones.service.spec.ts` — 19/19 passing.
- `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in other files confirmed present on `main` before this change).

## Batch context
closes #18
closes #26
closes #57
Closes #59