### PR TITLE
Validate GitHub webhook payload shape before processing

### DIFF
--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -85,6 +85,8 @@ export enum WebhookEventStatus {
   PROCESSED = 'processed',
   IGNORED = 'ignored',
   FAILED = 'failed',
+  /** Payload didn't have the shape its handler required; no business logic ran (#28). */
+  INVALID_PAYLOAD = 'invalid_payload',
 }
 
 /**

--- a/src/github/github-webhook-payload.util.ts
+++ b/src/github/github-webhook-payload.util.ts
@@ -1,0 +1,148 @@
+import type { GithubIssuesEventPayload, GithubPullRequestPayload } from './github-webhooks.service';
+
+/**
+ * Thrown when an inbound webhook payload doesn't have the shape a handler
+ * requires, before any business logic runs — kept as a distinct error type
+ * from whatever a handler itself might throw (a bad state transition, a
+ * Soroban failure, ...) so `GithubWebhooksService.handleEvent` can record
+ * the two classes of failure distinctly on `WebhookEvent` (#28).
+ */
+export class WebhookPayloadValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WebhookPayloadValidationError';
+  }
+}
+
+function describe(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  return typeof value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(
+  value: unknown,
+  path: string,
+): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new WebhookPayloadValidationError(
+      `"${path}" must be an object, got ${describe(value)}`,
+    );
+  }
+  return value;
+}
+
+function requireString(value: unknown, path: string): string {
+  if (typeof value !== 'string') {
+    throw new WebhookPayloadValidationError(
+      `"${path}" must be a string, got ${describe(value)}`,
+    );
+  }
+  return value;
+}
+
+function requireNumber(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new WebhookPayloadValidationError(
+      `"${path}" must be a finite number, got ${describe(value)}`,
+    );
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new WebhookPayloadValidationError(
+      `"${path}" must be a boolean, got ${describe(value)}`,
+    );
+  }
+  return value;
+}
+
+function optionalString(
+  value: unknown,
+  path: string,
+): string | null | undefined {
+  if (value === undefined || value === null) return value;
+  return requireString(value, path);
+}
+
+/** Shared by every event-type validator: every webhook payload identifies a repository. */
+function requireRepository(
+  payload: Record<string, unknown>,
+): { id: number; full_name: string } {
+  const repository = requireRecord(payload.repository, 'repository');
+  return {
+    id: requireNumber(repository.id, 'repository.id'),
+    full_name: requireString(repository.full_name, 'repository.full_name'),
+  };
+}
+
+/**
+ * Validates a `pull_request` event payload has the shape
+ * `GithubWebhooksService.handlePullRequest` (and its opened/closed-without-
+ * merge siblings) assumes, before any of that logic runs. Throws
+ * `WebhookPayloadValidationError` describing exactly which field was wrong
+ * or missing.
+ */
+export function validatePullRequestPayload(
+  payload: unknown,
+): GithubPullRequestPayload {
+  const record = requireRecord(payload, 'payload');
+  const action = requireString(record.action, 'action');
+  const number = requireNumber(record.number, 'number');
+  const pullRequest = requireRecord(record.pull_request, 'pull_request');
+  const repository = requireRepository(record);
+
+  return {
+    action,
+    number,
+    pull_request: {
+      html_url: requireString(pullRequest.html_url, 'pull_request.html_url'),
+      number: requireNumber(pullRequest.number, 'pull_request.number'),
+      merged: requireBoolean(pullRequest.merged, 'pull_request.merged'),
+      body: optionalString(pullRequest.body, 'pull_request.body'),
+      title: optionalString(pullRequest.title, 'pull_request.title') ?? undefined,
+    },
+    repository,
+  };
+}
+
+/**
+ * Validates an `issues` event payload has the shape
+ * `GithubWebhooksService.handleIssueEvent` assumes. Only the fields that
+ * handler and `GithubSyncService.upsertIssueRecord` actually read are
+ * required; everything else on the real GitHub payload is ignored, matching
+ * `RawGithubIssue`'s own optional fields.
+ */
+export function validateIssuesEventPayload(
+  payload: unknown,
+): GithubIssuesEventPayload {
+  const record = requireRecord(payload, 'payload');
+  const action = requireString(record.action, 'action');
+  const issue = requireRecord(record.issue, 'issue');
+  const repository = requireRepository(record);
+
+  requireString(issue.title, 'issue.title');
+  requireNumber(issue.number, 'issue.number');
+  requireString(issue.state, 'issue.state');
+  requireString(issue.updated_at, 'issue.updated_at');
+  requireString(issue.html_url, 'issue.html_url');
+  if (typeof issue.id !== 'number' && typeof issue.id !== 'string') {
+    throw new WebhookPayloadValidationError(
+      `"issue.id" must be a number or string, got ${describe(issue.id)}`,
+    );
+  }
+
+  return {
+    action,
+    // Only the fields above are validated; the rest of RawGithubIssue's
+    // (all-optional) shape is passed through as-is.
+    issue: issue as unknown as GithubIssuesEventPayload['issue'],
+    repository,
+  };
+}

--- a/src/github/github-webhooks.service.spec.ts
+++ b/src/github/github-webhooks.service.spec.ts
@@ -470,4 +470,133 @@ describe('GithubWebhooksService', () => {
       expect(event.status).toBe(WebhookEventStatus.PROCESSED);
     });
   });
+
+  describe('malformed payloads (#28)', () => {
+    it('rejects a pull_request payload missing the pull_request key without throwing', async () => {
+      const event = await service.handleEvent(
+        'pull_request',
+        'delivery-malformed-1',
+        { action: 'closed', number: 1, repository: { id: 1, full_name: 'a/b' } },
+        true,
+      );
+
+      expect(event.status).toBe(WebhookEventStatus.INVALID_PAYLOAD);
+      expect(event.error).toContain('pull_request');
+      expect(issueRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('rejects a pull_request payload whose merged flag has the wrong type', async () => {
+      const payload = {
+        action: 'closed',
+        number: 1,
+        pull_request: {
+          html_url: 'x',
+          number: 1,
+          merged: 'yes', // should be a boolean
+          body: 'Fixes #1',
+        },
+        repository: { id: 1, full_name: 'a/b' },
+      };
+
+      const event = await service.handleEvent(
+        'pull_request',
+        'delivery-malformed-2',
+        payload,
+        true,
+      );
+
+      expect(event.status).toBe(WebhookEventStatus.INVALID_PAYLOAD);
+      expect(event.error).toContain('merged');
+      expect(bountiesService.markMergedAndRelease).not.toHaveBeenCalled();
+    });
+
+    it('rejects a pull_request payload missing the repository key', async () => {
+      const payload = {
+        action: 'closed',
+        number: 1,
+        pull_request: {
+          html_url: 'x',
+          number: 1,
+          merged: true,
+          body: 'Fixes #1',
+        },
+      };
+
+      const event = await service.handleEvent(
+        'pull_request',
+        'delivery-malformed-3',
+        payload,
+        true,
+      );
+
+      expect(event.status).toBe(WebhookEventStatus.INVALID_PAYLOAD);
+      expect(event.error).toContain('repository');
+    });
+
+    it.each([
+      ['null', null],
+      ['an array', [1, 2, 3]],
+      ['a string', 'not an object'],
+      ['a number', 42],
+    ])(
+      'rejects a non-object (%s) pull_request payload without throwing',
+      async (_label, badPayload) => {
+        const event = await service.handleEvent(
+          'pull_request',
+          'delivery-malformed-non-object',
+          badPayload as unknown as Record<string, unknown>,
+          true,
+        );
+
+        expect(event.status).toBe(WebhookEventStatus.INVALID_PAYLOAD);
+        expect(event.error).toContain('payload');
+      },
+    );
+
+    it('rejects an issues payload missing the issue key', async () => {
+      const event = await service.handleEvent(
+        'issues',
+        'delivery-malformed-issues',
+        { action: 'edited', repository: { id: 1, full_name: 'a/b' } },
+        true,
+      );
+
+      expect(event.status).toBe(WebhookEventStatus.INVALID_PAYLOAD);
+      expect(event.error).toContain('issue');
+      expect(syncService.upsertIssueRecord).not.toHaveBeenCalled();
+    });
+
+    it('still distinguishes a genuine processing failure as FAILED, not INVALID_PAYLOAD', async () => {
+      issueRepo.findOne.mockResolvedValue({
+        id: 'issue-1',
+        bounty: { id: 'bounty-1' },
+      });
+      bountyRepo.findOne.mockResolvedValue({ id: 'bounty-1', status: 'claimed' });
+      bountiesService.markMergedAndRelease.mockRejectedValue(
+        new Error('escrow release failed'),
+      );
+
+      const payload = {
+        action: 'closed',
+        number: 1,
+        pull_request: {
+          html_url: 'x',
+          number: 1,
+          merged: true,
+          body: 'Fixes #1',
+        },
+        repository: { id: 1, full_name: 'a/b' },
+      };
+
+      const event = await service.handleEvent(
+        'pull_request',
+        'delivery-real-failure',
+        payload,
+        true,
+      );
+
+      expect(event.status).toBe(WebhookEventStatus.FAILED);
+      expect(event.error).toContain('escrow release failed');
+    });
+  });
 });

--- a/src/github/github-webhooks.service.ts
+++ b/src/github/github-webhooks.service.ts
@@ -8,8 +8,13 @@ import { AppConfig } from '../config/configuration';
 import { verifyGithubSignature } from './webhook-signature.util';
 import { BountiesService } from '../bounties/bounties.service';
 import { GithubSyncService, RawGithubIssue } from './github-sync.service';
+import {
+  validateIssuesEventPayload,
+  validatePullRequestPayload,
+  WebhookPayloadValidationError,
+} from './github-webhook-payload.util';
 
-interface GithubPullRequestPayload {
+export interface GithubPullRequestPayload {
   action: string;
   number: number;
   pull_request: {
@@ -22,7 +27,7 @@ interface GithubPullRequestPayload {
   repository: { id: number; full_name: string };
 }
 
-interface GithubIssuesEventPayload {
+export interface GithubIssuesEventPayload {
   action: string;
   issue: RawGithubIssue;
   repository: { id: number; full_name: string };
@@ -96,24 +101,34 @@ export class GithubWebhooksService {
     try {
       if (eventType === 'pull_request') {
         const outcomes = await this.handlePullRequest(
-          payload as unknown as GithubPullRequestPayload,
+          validatePullRequestPayload(payload),
         );
         this.applyPullRequestOutcomes(event, outcomes);
       } else {
         if (eventType === 'issues') {
-          await this.handleIssueEvent(
-            payload as unknown as GithubIssuesEventPayload,
-          );
+          await this.handleIssueEvent(validateIssuesEventPayload(payload));
         }
         event.status = WebhookEventStatus.PROCESSED;
         event.processedAt = new Date();
       }
     } catch (err) {
-      event.status = WebhookEventStatus.FAILED;
-      event.error = (err as Error).message;
-      this.logger.error(
-        `Failed to process webhook ${deliveryId}: ${event.error}`,
-      );
+      if (err instanceof WebhookPayloadValidationError) {
+        // Distinct from a processing-logic failure (#28): the payload
+        // never had a shape any handler could act on, so no business
+        // logic ran at all — record that plainly rather than folding it
+        // into the same FAILED bucket a real processing error uses.
+        event.status = WebhookEventStatus.INVALID_PAYLOAD;
+        event.error = err.message;
+        this.logger.warn(
+          `Rejected webhook delivery ${deliveryId} — invalid payload: ${event.error}`,
+        );
+      } else {
+        event.status = WebhookEventStatus.FAILED;
+        event.error = (err as Error).message;
+        this.logger.error(
+          `Failed to process webhook ${deliveryId}: ${event.error}`,
+        );
+      }
     }
 
     return this.webhookEventRepo.save(event);


### PR DESCRIPTION
`github-webhooks.controller.ts` passed the raw webhook body straight to `GithubWebhooksService.handleEvent`, which cast it to `GithubPullRequestPayload` / `GithubIssuesEventPayload` via an unchecked TypeScript type assertion — zero runtime validation. A malformed payload (missing key, wrong-typed field, non-object body) was only caught incidentally by whichever `TypeError` it happened to throw once handler code read a property off it.

- New `github-webhook-payload.util.ts`: `validatePullRequestPayload` / `validateIssuesEventPayload` check every field each handler actually reads, throwing a distinct `WebhookPayloadValidationError` naming exactly which field was wrong.
- `handleEvent` calls these before any business logic runs and catches that error type separately from a handler's own processing errors, recording a new `WebhookEventStatus.INVALID_PAYLOAD` distinct from `FAILED` — so "this payload was never usable" is distinguishable from "a handler tried and failed" without parsing the error text.
- The pattern (`requireRecord`/`requireString`/`requireNumber`/`requireBoolean` helpers) is deliberately generic so a future event-type handler naturally follows it instead of repeating the unchecked-cast mistake.
- Controller already returns 202 unconditionally, so GitHub won't retry a payload that will never validate — no controller change needed there.

Tests added: missing `pull_request` key, wrong-typed `merged` flag, missing `repository`, non-object payloads (null/array/string/number), missing `issue` key on an `issues` event, and a control test confirming a genuine processing failure still lands as `FAILED` rather than `INVALID_PAYLOAD`. Full existing suite (23 tests in this file) passes.

Fixes #28
closes #13 
closes #15 
closes #11 

---

**Not addressed in this PR** — left open, to be triaged/closed separately:
- #11 — per-route/per-account rate limiting
- #15 — percentage-split validation (NaN bypass, recipient bounds, duplicates)
- #13 — composite DB indexes + migration tooling