### PR TITLE
Implement caching for platform summary and add analytics TTL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,12 @@ ESCROW_DEADLINE_SECONDS=7776000
 # handling real funds.
 TREASURY_SECRET=
 
+# --- Analytics ---------------------------------------------------------
+# In-process TTL (ms) for GET /analytics/platform. Also invalidated when a
+# bounty is created/paid or a repository is first synced. Default 60000.
+# Per-process: multi-instance deploys may serve up to one TTL of stale data.
+ANALYTICS_PLATFORM_SUMMARY_TTL_MS=60000
+
 # --- Misc --------------------------------------------------------------
 # NestJS log verbosity: error | warn | log | debug | verbose
 LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Design principles:
 | `maintenance-pool` | Recurring sponsor deposits into a shared pool; maintainers assign rewards out of the running balance for maintenance-type work. |
 | `sponsors` | Sponsor dashboard: active bounties, total spend, budget locked in escrow, milestone progress, recent payments. |
 | `reputation` | Computes and snapshots per-contributor stats: earnings, merged PR count, completion rate, avg review time, on-time delivery %, languages, orgs. |
-| `analytics` | Lifetime earnings, repo/org counts, merge rate, review time, languages, a payout heatmap, and top clients (sponsors) per contributor; a platform-wide summary for the homepage. |
+| `analytics` | Lifetime earnings, repo/org counts, merge rate, review time, languages, a payout heatmap, and top clients (sponsors) per contributor; a platform-wide summary for the homepage. Contributor stats are SQL `GROUP BY` / `SUM` / `COUNT` (heatmap is UTC calendar days, capped at 366 buckets; top clients `ORDER BY` spend `LIMIT 10`). `GET /analytics/platform` is cached in-process for `ANALYTICS_PLATFORM_SUMMARY_TTL_MS` (default 60s) and invalidated when a bounty is created or paid or a repository is first synced. Multi-instance deploys may serve up to one TTL of stale data per process. |
 
 Cross-cutting: `config` (typed `@nestjs/config` configuration + `.env`),
 `common/entities` (all TypeORM entities + enums), Swagger mounted at
@@ -133,6 +133,7 @@ See [`.env.example`](./.env.example) for the full annotated list. Highlights:
 | `GITHUB_CLIENT_ID` / `_SECRET`, `GITHUB_OAUTH_CALLBACK_URL` | GitHub OAuth login app. |
 | `GITHUB_API_TOKEN` | Token used by Octokit for repo/issue sync (PAT for now; see roadmap). |
 | `GITHUB_WEBHOOK_SECRET` | HMAC-SHA256 secret configured on the GitHub webhook. |
+| `ANALYTICS_PLATFORM_SUMMARY_TTL_MS` | In-process TTL for `GET /analytics/platform` (default `60000`). Also invalidated on bounty create/pay and first repository sync. |
 | `STELLAR_NETWORK`, `SOROBAN_RPC_URL`, `STELLAR_NETWORK_PASSPHRASE` | Stellar network config. |
 | `ESCROW_CONTRACT_ID` | Deployed escrow contract ID from `mergefi-contracts`. **Not set in this environment** — see below. |
 | `MAINTENANCE_POOL_CONTRACT_ID` | Optional separate contract for maintenance-pool escrows; falls back to `ESCROW_CONTRACT_ID`. |
@@ -306,6 +307,7 @@ Unit tests cover critical domains including:
 - `src/bounties/bounties.service.spec.ts` — bounty core management.
 - `src/sponsors/sponsors.service.spec.ts` — sponsor dashboard aggregate queries (budgetLocked/totalSpend read the Escrow/Payment ledger directly).
 - `src/database/escrow-fk-integrity.integration.spec.ts` — **integration** test against a real Postgres (requires `DATABASE_URL`, not mocked): the exactly-one-parent CHECK constraint on `escrows`, and that sponsor dashboard figures survive a parent bounty/milestone being deleted.
+- `src/analytics/analytics.integration.spec.ts` — Postgres load/parity test: SQL heatmap + top-N match the old JS bucketing on a small fixture; a 3,000-bounty seed must not call `find`/`getMany` (O(n) entity load → O(days)+O(1) aggregates), `forContributor` under 2s, cached homepage summary on a second call.
 
 `DATABASE_SYNCHRONIZE=true` (set in development) will auto-create tables from entities for fast local iteration. Real deployments should run migrations instead — see `src/database/migrations/` and the `migration:*` npm scripts below.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,9 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -3887,9 +3890,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3904,9 +3904,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3921,9 +3918,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3938,9 +3932,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3955,9 +3946,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3972,9 +3960,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3989,9 +3974,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4006,9 +3988,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4023,9 +4002,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4040,9 +4016,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Param } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { HEATMAP_MAX_DAYS } from '../common/stats/contributor-stats.sql';
 import { AnalyticsService } from './analytics.service';
 
 @ApiTags('analytics')
@@ -8,11 +9,26 @@ export class AnalyticsController {
   constructor(private readonly analyticsService: AnalyticsService) {}
 
   @Get('contributors/:userId')
-  forContributor(@Param('userId') userId: string) {
-    return this.analyticsService.forContributor(userId);
+  @ApiOperation({
+    summary: 'Contributor analytics (SQL-aggregated)',
+    description:
+      'Lifetime earnings, repo/org counts, merge rate, review time, languages, a UTC calendar-day payout heatmap (capped at 366 most recent days), and top 10 sponsors by spend. Optional from/to (YYYY-MM-DD, UTC) bound the heatmap; the span cannot exceed 366 days.',
+  })
+  @ApiQuery({ name: 'from', required: false, example: '2023-01-01' })
+  @ApiQuery({ name: 'to', required: false, example: '2023-12-31' })
+  forContributor(
+    @Param('userId', new ParseUUIDPipe()) userId: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.analyticsService.forContributor(userId, { from, to });
   }
 
   @Get('platform')
+  @ApiOperation({
+    summary: 'Platform-wide homepage summary',
+    description: `Cached in-process for ANALYTICS_PLATFORM_SUMMARY_TTL_MS (default 60s). Invalidated when a bounty is created or paid, or a repository is first synced. Heatmap/day cap is ${HEATMAP_MAX_DAYS}. Multi-instance deployments may serve up to one TTL of stale data per process.`,
+  })
   platformSummary() {
     return this.analyticsService.platformSummary();
   }

--- a/src/analytics/analytics.events.ts
+++ b/src/analytics/analytics.events.ts
@@ -1,0 +1,3 @@
+/** Emitted when platform-wide counters (bounty count, paid-out sum, repo count) change. */
+export const ANALYTICS_PLATFORM_INVALIDATE_EVENT =
+  'analytics.platform.invalidate';

--- a/src/analytics/analytics.integration.spec.ts
+++ b/src/analytics/analytics.integration.spec.ts
@@ -1,0 +1,301 @@
+import { randomUUID } from 'crypto';
+import { ConfigService } from '@nestjs/config';
+import { DataSource, Repository, SelectQueryBuilder } from 'typeorm';
+import { entities } from '../common/entities/typeorm-entities';
+import {
+  Bounty,
+  Issue,
+  ReputationSnapshot,
+  Repository as Repo,
+  User,
+} from '../common/entities';
+import { AssetType, BountyDifficulty, BountyStatus } from '../common/enums';
+import { AnalyticsService } from '../analytics/analytics.service';
+import { AppConfig } from '../config/configuration';
+import { computeContributorStats } from '../common/stats/contributor-stats.util';
+import { ReputationService } from '../reputation/reputation.service';
+
+/**
+ * Load / correctness test for analytics SQL aggregation (#heatmap / top-N /
+ * homepage cache).
+ *
+ * Big-O change:
+ * - Before: `bountyRepo.find({ claimedById })` loaded O(n) Bounty entities
+ *   plus O(n) Issue rows into Node, then Map/sort in JS (n = claimed
+ *   bounties). A 3_000-row seed would hydrate 3_000+3_000 entities.
+ * - After: GROUP BY / SUM / COUNT / LIMIT 10 queries; app memory is
+ *   O(D) heatmap days (D ≤ 366) + O(1) top-clients + O(L) languages.
+ *   Homepage summary is O(1) rows per query and O(1) after the in-process TTL.
+ *
+ * Wall-clock is environment-dependent; the find/getMany spies and bounded
+ * array lengths are the real gate. Query budget: forContributor < 2s on
+ * this seed; cached platformSummary second call should be trivial.
+ *
+ * Isolated in schema `analytics_itest` so it can run alongside the escrow
+ * FK integration spec without dropSchema races.
+ */
+describe('Analytics SQL aggregation (integration)', () => {
+  let dataSource: DataSource;
+  let bountyRepo: Repository<Bounty>;
+  let issueRepo: Repository<Issue>;
+  let repoRepo: Repository<Repo>;
+  let userRepo: Repository<User>;
+  let analytics: AnalyticsService;
+  let reputation: ReputationService;
+  let dbAvailable = false;
+
+  const SEED_PAID = 3_000;
+  const SEED_DAYS = 180;
+  const SEED_SPONSORS = 40;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'postgres',
+      url:
+        process.env.DATABASE_URL ??
+        'postgresql://postgres:postgres@localhost:5432/mergefi',
+      schema: 'analytics_itest',
+      entities,
+      synchronize: true,
+      dropSchema: true,
+    });
+    try {
+      await dataSource.initialize();
+    } catch (err) {
+      console.warn(
+        'Skipping analytics integration tests: Postgres is not reachable at DATABASE_URL.',
+        err,
+      );
+      return;
+    }
+    dbAvailable = true;
+
+    bountyRepo = dataSource.getRepository(Bounty);
+    issueRepo = dataSource.getRepository(Issue);
+    repoRepo = dataSource.getRepository(Repo);
+    userRepo = dataSource.getRepository(User);
+
+    const configService = {
+      get: () => ({ platformSummaryTtlMs: 60_000 }),
+    } as unknown as ConfigService<AppConfig, true>;
+    analytics = new AnalyticsService(bountyRepo, repoRepo, configService);
+    reputation = new ReputationService(
+      bountyRepo,
+      dataSource.getRepository(ReputationSnapshot),
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) await dataSource.destroy();
+  });
+
+  it('matches JS contributor-stats on a small fixture (UTC heatmap + top-10)', async () => {
+    if (!dbAvailable) {
+      expect(process.env.CI).not.toBe('true');
+      return;
+    }
+    const contributor = await userRepo.save(
+      userRepo.create({ username: `gold-contrib-${randomUUID()}` }),
+    );
+    const sponsorA = await userRepo.save(
+      userRepo.create({ username: `gold-a-${randomUUID()}` }),
+    );
+    const sponsorB = await userRepo.save(
+      userRepo.create({ username: `gold-b-${randomUUID()}` }),
+    );
+    const repository = await repoRepo.save(
+      repoRepo.create({
+        githubRepoId: `gold-${randomUUID()}`,
+        owner: 'acme',
+        name: 'widgets',
+        fullName: 'acme/widgets',
+        primaryLanguage: 'TypeScript',
+      }),
+    );
+    const repo2 = await repoRepo.save(
+      repoRepo.create({
+        githubRepoId: `gold-${randomUUID()}`,
+        owner: 'acme',
+        name: 'tools',
+        fullName: 'acme/tools',
+        primaryLanguage: 'TypeScript',
+      }),
+    );
+
+    const issues: Issue[] = [];
+    const claimed: Bounty[] = [];
+    const specs: Array<{
+      amount: string;
+      paidAt: Date;
+      sponsorId: string;
+      repositoryId: string;
+    }> = [
+      {
+        amount: '100',
+        paidAt: new Date('2023-01-01T10:00:00Z'),
+        sponsorId: sponsorA.id,
+        repositoryId: repository.id,
+      },
+      {
+        amount: '200',
+        paidAt: new Date('2023-01-01T15:00:00Z'),
+        sponsorId: sponsorB.id,
+        repositoryId: repo2.id,
+      },
+      {
+        amount: '50',
+        paidAt: new Date('2023-01-02T10:00:00Z'),
+        sponsorId: sponsorA.id,
+        repositoryId: repository.id,
+      },
+    ];
+    for (const spec of specs) {
+      const issue = await issueRepo.save(
+        issueRepo.create({
+          repositoryId: spec.repositoryId,
+          githubIssueId: `gold-issue-${randomUUID()}`,
+          number: issues.length + 1,
+          title: 'gold',
+          githubUrl: 'https://github.com/acme/widgets/issues/1',
+        }),
+      );
+      const linkedRepo =
+        spec.repositoryId === repository.id ? repository : repo2;
+      issue.repository = linkedRepo;
+      issues.push(issue);
+      const bounty = await bountyRepo.save(
+        bountyRepo.create({
+          issueId: issue.id,
+          sponsorId: spec.sponsorId,
+          claimedById: contributor.id,
+          amount: spec.amount,
+          asset: AssetType.USDC,
+          difficulty: BountyDifficulty.INTERMEDIATE,
+          status: BountyStatus.PAID,
+          paidAt: spec.paidAt,
+          claimedAt: new Date('2022-12-31T00:00:00Z'),
+          mergedAt: new Date('2023-01-01T00:00:00Z'),
+        }),
+      );
+      claimed.push(bounty);
+    }
+
+    const js = computeContributorStats(claimed, issues);
+    const sqlResult = await analytics.forContributor(contributor.id);
+
+    expect(sqlResult.mergeRate).toBe(js.completionRate);
+    expect(sqlResult.languages).toEqual(js.languages);
+    expect(sqlResult.orgCount).toBe(js.orgs.length);
+    expect(sqlResult.repoCount).toBe(2);
+    expect(sqlResult.lifetimeEarnings).toBe(350);
+    expect(sqlResult.heatmap).toEqual([
+      { date: '2023-01-01', count: 2 },
+      { date: '2023-01-02', count: 1 },
+    ]);
+    expect(sqlResult.topClients).toEqual([
+      { sponsorId: sponsorB.id, totalPaid: 200 },
+      { sponsorId: sponsorA.id, totalPaid: 150 },
+    ]);
+    expect(sqlResult.avgReviewTimeHours).toBeCloseTo(js.avgReviewTimeHours, 5);
+  });
+
+  it('aggregates thousands of paid bounties without hydrating them in Node', async () => {
+    if (!dbAvailable) {
+      expect(process.env.CI).not.toBe('true');
+      return;
+    }
+    const contributor = await userRepo.save(
+      userRepo.create({ username: `load-contrib-${randomUUID()}` }),
+    );
+    const sponsors: User[] = [];
+    for (let i = 0; i < SEED_SPONSORS; i++) {
+      sponsors.push(
+        await userRepo.save(
+          userRepo.create({ username: `load-sponsor-${i}-${randomUUID()}` }),
+        ),
+      );
+    }
+    const repos: Repo[] = [];
+    for (let i = 0; i < 12; i++) {
+      repos.push(
+        await repoRepo.save(
+          repoRepo.create({
+            githubRepoId: `load-repo-${i}-${randomUUID()}`,
+            owner: `org-${i % 6}`,
+            name: `repo-${i}`,
+            fullName: `org-${i % 6}/repo-${i}`,
+            primaryLanguage: i % 2 === 0 ? 'TypeScript' : 'Rust',
+          }),
+        ),
+      );
+    }
+
+    const issueValues: Partial<Issue>[] = [];
+    const bountyValues: Partial<Bounty>[] = [];
+    for (let i = 0; i < SEED_PAID; i++) {
+      const issueId = randomUUID();
+      const repo = repos[i % repos.length];
+      issueValues.push({
+        id: issueId,
+        repositoryId: repo.id,
+        githubIssueId: `load-issue-${i}-${randomUUID()}`,
+        number: i + 1,
+        title: `Issue ${i}`,
+        githubUrl: `https://github.com/org/repo/issues/${i}`,
+        labels: [],
+      });
+      const day = i % SEED_DAYS;
+      bountyValues.push({
+        id: randomUUID(),
+        issueId,
+        sponsorId: sponsors[i % sponsors.length].id,
+        claimedById: contributor.id,
+        amount: '10',
+        asset: AssetType.USDC,
+        difficulty: BountyDifficulty.INTERMEDIATE,
+        status: BountyStatus.PAID,
+        paidAt: new Date(Date.UTC(2024, 0, 1 + day, 15, 0, 0)),
+        claimedAt: new Date(Date.UTC(2023, 11, 1, 0, 0, 0)),
+        mergedAt: new Date(Date.UTC(2023, 11, 2, 0, 0, 0)),
+      });
+    }
+
+    const chunk = 500;
+    for (let i = 0; i < issueValues.length; i += chunk) {
+      await issueRepo.insert(issueValues.slice(i, i + chunk));
+      await bountyRepo.insert(bountyValues.slice(i, i + chunk));
+    }
+
+    const findSpy = jest.spyOn(bountyRepo, 'find');
+    const getManySpy = jest.spyOn(SelectQueryBuilder.prototype, 'getMany');
+
+    try {
+      const started = Date.now();
+      const result = await analytics.forContributor(contributor.id);
+      const elapsedMs = Date.now() - started;
+
+      expect(findSpy).not.toHaveBeenCalled();
+      expect(getManySpy).not.toHaveBeenCalled();
+      expect(result.heatmap.length).toBe(SEED_DAYS);
+      expect(result.heatmap.length).toBeLessThanOrEqual(366);
+      expect(result.topClients.length).toBeLessThanOrEqual(10);
+      expect(result.topClients.length).toBe(10);
+      expect(result.lifetimeEarnings).toBe(SEED_PAID * 10);
+      expect(elapsedMs).toBeLessThan(2_000);
+    } finally {
+      findSpy.mockRestore();
+      getManySpy.mockRestore();
+    }
+
+    const snap = await reputation.computeAndSave(contributor.id);
+    expect(Number(snap.totalEarnings)).toBe(SEED_PAID * 10);
+    expect(snap.mergedPrCount).toBe(SEED_PAID);
+
+    await analytics.platformSummary();
+    const cachedStart = Date.now();
+    const cached = await analytics.platformSummary();
+    const cachedMs = Date.now() - cachedStart;
+    expect(cached.totalBounties).toBeGreaterThanOrEqual(SEED_PAID);
+    expect(cachedMs).toBeLessThan(50);
+  }, 60_000);
+});

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Bounty, Issue, Repository } from '../common/entities';
+import { Bounty, Repository } from '../common/entities';
 import { AnalyticsService } from './analytics.service';
 import { AnalyticsController } from './analytics.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Bounty, Issue, Repository])],
+  imports: [TypeOrmModule.forFeature([Bounty, Repository])],
   controllers: [AnalyticsController],
   providers: [AnalyticsService],
   exports: [AnalyticsService],

--- a/src/analytics/analytics.service.spec.ts
+++ b/src/analytics/analytics.service.spec.ts
@@ -1,23 +1,94 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service';
-import { Bounty, Issue, Repository as RepositoryEntity } from '../common/entities';
-import { BountyStatus } from '../common/enums';
-import * as statsUtil from '../common/stats/contributor-stats.util';
+import { Bounty, Repository as RepositoryEntity } from '../common/entities';
+import * as sql from '../common/stats/contributor-stats.sql';
+import { heatmapRange } from '../common/stats/contributor-stats.sql';
+import { TtlCache } from './ttl-cache';
+
+jest.mock('../common/stats/contributor-stats.sql', () => {
+  return {
+    ...jest.requireActual<
+      typeof import('../common/stats/contributor-stats.sql')
+    >('../common/stats/contributor-stats.sql'),
+    queryContributorCoreStats: jest.fn(),
+    queryPayoutHeatmap: jest.fn(),
+    queryTopClients: jest.fn(),
+  };
+});
+
+const mockedSql = sql as jest.Mocked<typeof sql>;
+
+describe('heatmapRange', () => {
+  it('rejects an inverted from/to window', () => {
+    expect(() => heatmapRange('2023-02-01', '2023-01-01')).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it(`rejects a span longer than ${sql.HEATMAP_MAX_DAYS} days`, () => {
+    expect(() => heatmapRange('2020-01-01', '2022-01-02')).toThrow(
+      BadRequestException,
+    );
+  });
+});
+
+describe('TtlCache', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the cached value until TTL elapses', async () => {
+    const cache = new TtlCache<number>(1_000);
+    const loader = jest.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+
+    expect(await cache.getOrLoad(loader)).toBe(1);
+    expect(await cache.getOrLoad(loader)).toBe(1);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1_001);
+    expect(await cache.getOrLoad(loader)).toBe(2);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent misses onto one loader call', async () => {
+    const cache = new TtlCache<string>(60_000);
+    let resolveLoad!: (value: string) => void;
+    const loader = jest.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+
+    const a = cache.getOrLoad(loader);
+    const b = cache.getOrLoad(loader);
+    resolveLoad('shared');
+    expect(await Promise.all([a, b])).toEqual(['shared', 'shared']);
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidate drops the cached entry', async () => {
+    const cache = new TtlCache<number>(60_000);
+    const loader = jest.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+    await cache.getOrLoad(loader);
+    cache.invalidate();
+    expect(await cache.getOrLoad(loader)).toBe(2);
+  });
+});
 
 describe('AnalyticsService', () => {
   let service: AnalyticsService;
-
   const mockBountyRepo = {
     find: jest.fn(),
     count: jest.fn(),
     createQueryBuilder: jest.fn(),
   };
-
-  const mockIssueRepo = {
-    find: jest.fn(),
-  };
-
   const mockRepositoryRepo = {
     count: jest.fn(),
   };
@@ -27,12 +98,20 @@ describe('AnalyticsService', () => {
       providers: [
         AnalyticsService,
         { provide: getRepositoryToken(Bounty), useValue: mockBountyRepo },
-        { provide: getRepositoryToken(Issue), useValue: mockIssueRepo },
-        { provide: getRepositoryToken(RepositoryEntity), useValue: mockRepositoryRepo },
+        {
+          provide: getRepositoryToken(RepositoryEntity),
+          useValue: mockRepositoryRepo,
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: () => ({ platformSummaryTtlMs: 60_000 }),
+          },
+        },
       ],
     }).compile();
 
-    service = module.get<AnalyticsService>(AnalyticsService);
+    service = module.get(AnalyticsService);
   });
 
   afterEach(() => {
@@ -40,16 +119,26 @@ describe('AnalyticsService', () => {
   });
 
   it('should handle empty input correctly (zero bounties)', async () => {
-    mockBountyRepo.find.mockResolvedValue([]);
-    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+    mockedSql.queryContributorCoreStats.mockResolvedValue({
+      claimedCount: 0,
       mergedCount: 0,
       completionRate: 0,
       avgReviewTimeHours: 0,
+      lifetimeEarnings: 0,
+      openBountiesClaimed: 0,
+      onTimeCount: 0,
+      onTimeDeliveryPercentage: 0,
+      repoCount: 0,
+      orgCount: 0,
       languages: {},
       orgs: [],
     });
+    mockedSql.queryPayoutHeatmap.mockResolvedValue([]);
+    mockedSql.queryTopClients.mockResolvedValue([]);
 
-    const result = await service.forContributor('user-1');
+    const result = await service.forContributor(
+      '11111111-1111-4111-8111-111111111111',
+    );
     expect(result.lifetimeEarnings).toBe(0);
     expect(result.repoCount).toBe(0);
     expect(result.orgCount).toBe(0);
@@ -57,37 +146,70 @@ describe('AnalyticsService', () => {
     expect(result.avgReviewTimeHours).toBe(0);
     expect(result.heatmap).toEqual([]);
     expect(result.topClients).toEqual([]);
+    expect(mockBountyRepo.find).not.toHaveBeenCalled();
   });
 
   it('should compute heatmap date-bucketing and merge-rate correctly', async () => {
-    mockBountyRepo.find.mockResolvedValue([
-      { id: 'b1', issueId: 'i1', amount: '100', status: BountyStatus.PAID, paidAt: new Date('2023-01-01T10:00:00Z'), sponsorId: 'client-A' },
-      { id: 'b2', issueId: 'i2', amount: '200', status: BountyStatus.PAID, paidAt: new Date('2023-01-01T15:00:00Z'), sponsorId: 'client-B' },
-      { id: 'b3', issueId: 'i3', amount: '50', status: BountyStatus.PAID, paidAt: new Date('2023-01-02T10:00:00Z'), sponsorId: 'client-A' },
-    ]);
-    mockIssueRepo.find.mockResolvedValue([
-      { id: 'i1', repositoryId: 'r1' },
-      { id: 'i2', repositoryId: 'r2' },
-      { id: 'i3', repositoryId: 'r1' },
-    ]);
-    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+    mockedSql.queryContributorCoreStats.mockResolvedValue({
+      claimedCount: 3,
       mergedCount: 3,
       completionRate: 100,
       avgReviewTimeHours: 2,
+      lifetimeEarnings: 350,
+      openBountiesClaimed: 0,
+      onTimeCount: 3,
+      onTimeDeliveryPercentage: 100,
+      repoCount: 2,
+      orgCount: 1,
       languages: { TypeScript: 3 },
       orgs: ['org1'],
     });
+    mockedSql.queryPayoutHeatmap.mockResolvedValue([
+      { date: '2023-01-01', count: 2 },
+      { date: '2023-01-02', count: 1 },
+    ]);
+    mockedSql.queryTopClients.mockResolvedValue([
+      { sponsorId: 'client-B', totalPaid: 200 },
+      { sponsorId: 'client-A', totalPaid: 150 },
+    ]);
 
-    const result = await service.forContributor('user-1');
+    const result = await service.forContributor(
+      '11111111-1111-4111-8111-111111111111',
+    );
     expect(result.mergeRate).toBe(100);
     expect(result.heatmap).toEqual([
       { date: '2023-01-01', count: 2 },
       { date: '2023-01-02', count: 1 },
     ]);
-    // Sorted by total paid (B=200, A=150)
     expect(result.topClients).toEqual([
       { sponsorId: 'client-B', totalPaid: 200 },
       { sponsorId: 'client-A', totalPaid: 150 },
     ]);
+  });
+
+  it('serves platformSummary from cache until invalidate', async () => {
+    mockBountyRepo.count.mockResolvedValue(4);
+    mockBountyRepo.createQueryBuilder.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getRawOne: jest.fn().mockResolvedValue({ total: '10' }),
+    });
+    mockRepositoryRepo.count.mockResolvedValue(2);
+
+    const first = await service.platformSummary();
+    const second = await service.platformSummary();
+    expect(first).toEqual({
+      totalBounties: 4,
+      totalPaidOut: 10,
+      totalRepos: 2,
+    });
+    expect(second).toEqual(first);
+    expect(mockBountyRepo.count).toHaveBeenCalledTimes(1);
+
+    service.invalidatePlatformSummary();
+    mockBountyRepo.count.mockResolvedValue(5);
+    const third = await service.platformSummary();
+    expect(third.totalBounties).toBe(5);
+    expect(mockBountyRepo.count).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -1,13 +1,19 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OnEvent } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import {
-  Bounty,
-  Issue,
-  Repository as RepositoryEntity,
-} from '../common/entities';
+import { Bounty, Repository as RepositoryEntity } from '../common/entities';
 import { BountyStatus } from '../common/enums';
-import { computeContributorStats } from '../common/stats/contributor-stats.util';
+import { AppConfig } from '../config/configuration';
+import {
+  heatmapRange,
+  queryContributorCoreStats,
+  queryPayoutHeatmap,
+  queryTopClients,
+} from '../common/stats/contributor-stats.sql';
+import { ANALYTICS_PLATFORM_INVALIDATE_EVENT } from './analytics.events';
+import { TtlCache } from './ttl-cache';
 
 export interface ContributorAnalytics {
   lifetimeEarnings: number;
@@ -20,60 +26,48 @@ export interface ContributorAnalytics {
   topClients: Array<{ sponsorId: string; totalPaid: number }>;
 }
 
+export interface ContributorAnalyticsQuery {
+  from?: string;
+  to?: string;
+}
+
+export interface PlatformSummary {
+  totalBounties: number;
+  totalPaidOut: number;
+  totalRepos: number;
+}
+
 @Injectable()
 export class AnalyticsService {
+  private readonly platformCache: TtlCache<PlatformSummary>;
+
   constructor(
     @InjectRepository(Bounty) private readonly bountyRepo: Repository<Bounty>,
-    @InjectRepository(Issue) private readonly issueRepo: Repository<Issue>,
     @InjectRepository(RepositoryEntity)
     private readonly repositoryRepo: Repository<RepositoryEntity>,
-  ) {}
+    configService: ConfigService<AppConfig, true>,
+  ) {
+    const ttlMs = configService.get('analytics', {
+      infer: true,
+    }).platformSummaryTtlMs;
+    this.platformCache = new TtlCache<PlatformSummary>(ttlMs);
+  }
 
-  async forContributor(userId: string): Promise<ContributorAnalytics> {
-    const claimed = await this.bountyRepo.find({
-      where: { claimedById: userId },
-    });
-    const paid = claimed.filter((b) => b.status === BountyStatus.PAID);
-
-    const issues = claimed.length
-      ? await this.issueRepo.find({
-          where: claimed.map((b) => ({ id: b.issueId })),
-          relations: { repository: true },
-        })
-      : [];
-
-    const stats = computeContributorStats(claimed, issues);
-
-    const lifetimeEarnings = paid.reduce((sum, b) => sum + Number(b.amount), 0);
-    const repoIds = new Set(issues.map((i) => i.repositoryId));
-
-    const heatmapMap = new Map<string, number>();
-    for (const bounty of paid) {
-      if (!bounty.paidAt) continue;
-      const day = bounty.paidAt.toISOString().slice(0, 10);
-      heatmapMap.set(day, (heatmapMap.get(day) ?? 0) + 1);
-    }
-    const heatmap = [...heatmapMap.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, count]) => ({ date, count }));
-
-    const clientTotals = new Map<string, number>();
-    for (const bounty of paid) {
-      if (!bounty.sponsorId) continue;
-      clientTotals.set(
-        bounty.sponsorId,
-        (clientTotals.get(bounty.sponsorId) ?? 0) + Number(bounty.amount),
-      );
-    }
-    const topClients = [...clientTotals.entries()]
-      .map(([sponsorId, totalPaid]) => ({ sponsorId, totalPaid }))
-      .sort((a, b) => b.totalPaid - a.totalPaid)
-      .slice(0, 10);
+  async forContributor(
+    userId: string,
+    query: ContributorAnalyticsQuery = {},
+  ): Promise<ContributorAnalytics> {
+    const range = heatmapRange(query.from, query.to);
+    const [stats, heatmap, topClients] = await Promise.all([
+      queryContributorCoreStats(this.bountyRepo, userId),
+      queryPayoutHeatmap(this.bountyRepo, userId, range),
+      queryTopClients(this.bountyRepo, userId),
+    ]);
 
     return {
-      lifetimeEarnings,
-      repoCount: repoIds.size,
-      orgCount: stats.orgs.length,
+      lifetimeEarnings: stats.lifetimeEarnings,
+      repoCount: stats.repoCount,
+      orgCount: stats.orgCount,
       mergeRate: stats.completionRate,
       avgReviewTimeHours: stats.avgReviewTimeHours,
       languages: stats.languages,
@@ -82,8 +76,21 @@ export class AnalyticsService {
     };
   }
 
-  /** Platform-wide stats for the homepage / admin view. */
-  async platformSummary() {
+  /**
+   * Platform-wide stats for the homepage. Cached in-process with a TTL
+   * (ANALYTICS_PLATFORM_SUMMARY_TTL_MS, default 60s) and busted on bounty
+   * create/pay and new repository insert. Concurrent misses share one query.
+   */
+  async platformSummary(): Promise<PlatformSummary> {
+    return this.platformCache.getOrLoad(() => this.loadPlatformSummary());
+  }
+
+  @OnEvent(ANALYTICS_PLATFORM_INVALIDATE_EVENT)
+  invalidatePlatformSummary(): void {
+    this.platformCache.invalidate();
+  }
+
+  private async loadPlatformSummary(): Promise<PlatformSummary> {
     const [totalBounties, totalPaidRaw, totalRepos] = await Promise.all([
       this.bountyRepo.count(),
       this.bountyRepo

--- a/src/analytics/ttl-cache.ts
+++ b/src/analytics/ttl-cache.ts
@@ -1,0 +1,34 @@
+/**
+ * Process-local TTL cache with single-flight load coalescing so concurrent
+ * misses share one loader call (thundering-herd protection).
+ */
+export class TtlCache<T> {
+  private entry: { data: T; expiresAt: number } | null = null;
+  private inflight: Promise<T> | null = null;
+
+  constructor(private readonly ttlMs: number) {}
+
+  invalidate(): void {
+    this.entry = null;
+  }
+
+  async getOrLoad(loader: () => Promise<T>): Promise<T> {
+    const now = Date.now();
+    if (this.entry && now < this.entry.expiresAt) {
+      return this.entry.data;
+    }
+    if (this.inflight) {
+      return this.inflight;
+    }
+    this.inflight = (async () => {
+      try {
+        const data = await loader();
+        this.entry = { data, expiresAt: Date.now() + this.ttlMs };
+        return data;
+      } finally {
+        this.inflight = null;
+      }
+    })();
+    return this.inflight;
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -24,6 +25,7 @@ import { IdempotencyModule } from './common/idempotency/idempotency.module';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true, load: [configuration] }),
+    EventEmitterModule.forRoot(),
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 120 }]),
     ScheduleModule.forRoot(),
     TypeOrmModule.forRootAsync({

--- a/src/bounties/bounties.service.spec.ts
+++ b/src/bounties/bounties.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { BountiesService } from './bounties.service';
 import { EscrowService } from '../escrow/escrow.service';
 import { Bounty, Team, User } from '../common/entities';
@@ -52,6 +53,7 @@ describe('BountiesService', () => {
         { provide: getRepositoryToken(User), useValue: userRepo },
         { provide: getRepositoryToken(Team), useValue: teamRepo },
         { provide: EscrowService, useValue: escrowService },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/src/bounties/bounties.service.ts
+++ b/src/bounties/bounties.service.ts
@@ -1,8 +1,10 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Optional } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Bounty, Team, User } from '../common/entities';
 import { AssetType, BountyDifficulty, BountyStatus } from '../common/enums';
+import { ANALYTICS_PLATFORM_INVALIDATE_EVENT } from '../analytics/analytics.events';
 import { assertTransition } from './bounty-state-machine';
 import { EscrowService } from '../escrow/escrow.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
@@ -22,6 +24,7 @@ export class BountiesService {
     @InjectRepository(User) private readonly userRepo: Repository<User>,
     @InjectRepository(Team) private readonly teamRepo: Repository<Team>,
     private readonly escrowService: EscrowService,
+    @Optional() private readonly eventEmitter?: EventEmitter2,
   ) {}
 
   async create(dto: CreateBountyDto): Promise<Bounty> {
@@ -34,7 +37,9 @@ export class BountiesService {
       deadline: dto.deadline ? new Date(dto.deadline) : null,
       status: BountyStatus.OPEN,
     });
-    return this.bountyRepo.save(bounty);
+    const saved = await this.bountyRepo.save(bounty);
+    this.eventEmitter?.emit(ANALYTICS_PLATFORM_INVALIDATE_EVENT);
+    return saved;
   }
 
   async findOne(id: string): Promise<Bounty> {
@@ -159,7 +164,9 @@ export class BountiesService {
     assertTransition(bounty.status, BountyStatus.PAID);
     bounty.status = BountyStatus.PAID;
     bounty.paidAt = new Date();
-    return this.bountyRepo.save(bounty);
+    const paid = await this.bountyRepo.save(bounty);
+    this.eventEmitter?.emit(ANALYTICS_PLATFORM_INVALIDATE_EVENT);
+    return paid;
   }
 
   /** Sponsor (or admin/expiry job) reclaims escrowed funds. */

--- a/src/common/entities/bounty.entity.ts
+++ b/src/common/entities/bounty.entity.ts
@@ -16,6 +16,13 @@ import { Escrow } from './escrow.entity';
 import { AssetType, BountyDifficulty, BountyStatus } from '../enums';
 
 @Entity('bounties')
+@Index('IDX_bounties_claimedById_status', ['claimedById', 'status'])
+@Index('IDX_bounties_status_paid', ['status'], {
+  where: `"status" = 'paid'`,
+})
+@Index('IDX_bounties_paidAt_paid', ['paidAt'], {
+  where: `"status" = 'paid' AND "paidAt" IS NOT NULL`,
+})
 export class Bounty {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/common/stats/contributor-stats.sql.ts
+++ b/src/common/stats/contributor-stats.sql.ts
@@ -1,0 +1,237 @@
+import { BadRequestException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { Bounty } from '../entities';
+import { BountyStatus } from '../enums';
+import { MERGED_BOUNTY_STATUSES } from './contributor-stats.util';
+
+/** Max calendar-day buckets returned for a payout heatmap. */
+export const HEATMAP_MAX_DAYS = 366;
+
+export const TOP_CLIENTS_LIMIT = 10;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** UTC calendar-day expression matching `Date#toISOString().slice(0, 10)`. */
+export const PAYOUT_UTC_DATE_SQL = `to_char((bounty.paidAt AT TIME ZONE 'UTC'), 'YYYY-MM-DD')`;
+
+const MERGED_SQL = MERGED_BOUNTY_STATUSES.map((s) => `'${s}'`).join(', ');
+
+export interface HeatmapBucket {
+  date: string;
+  count: number;
+}
+
+export interface TopClientRow {
+  sponsorId: string;
+  totalPaid: number;
+}
+
+export interface ContributorCoreSqlStats {
+  claimedCount: number;
+  mergedCount: number;
+  completionRate: number;
+  avgReviewTimeHours: number;
+  lifetimeEarnings: number;
+  openBountiesClaimed: number;
+  onTimeCount: number;
+  onTimeDeliveryPercentage: number;
+  repoCount: number;
+  orgCount: number;
+  languages: Record<string, number>;
+  orgs: string[];
+}
+
+export interface HeatmapRange {
+  from?: Date;
+  toExclusive?: Date;
+}
+
+export function parseUtcDateOnly(value: string, param: string): Date {
+  if (!ISO_DATE.test(value)) {
+    throw new BadRequestException(`${param} must be YYYY-MM-DD`);
+  }
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new BadRequestException(`${param} is not a valid calendar date`);
+  }
+  return date;
+}
+
+/** Inclusive UTC `from`/`to` dates; `toExclusive` is the next UTC midnight. */
+export function heatmapRange(from?: string, to?: string): HeatmapRange {
+  const fromDate = from ? parseUtcDateOnly(from, 'from') : undefined;
+  const toDate = to ? parseUtcDateOnly(to, 'to') : undefined;
+  if (fromDate && toDate && fromDate > toDate) {
+    throw new BadRequestException('from must be on or before to');
+  }
+  if (fromDate && toDate) {
+    const days = (toDate.getTime() - fromDate.getTime()) / 86_400_000 + 1;
+    if (days > HEATMAP_MAX_DAYS) {
+      throw new BadRequestException(
+        `heatmap window cannot exceed ${HEATMAP_MAX_DAYS} days`,
+      );
+    }
+  }
+  return {
+    from: fromDate,
+    toExclusive: toDate ? new Date(toDate.getTime() + 86_400_000) : undefined,
+  };
+}
+
+export function heatmapFromRaw(
+  rows: Array<{ date: string; count: string | number }>,
+): HeatmapBucket[] {
+  return rows
+    .map((row) => ({ date: row.date, count: Number(row.count) }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export async function queryPayoutHeatmap(
+  bountyRepo: Repository<Bounty>,
+  userId: string,
+  range: HeatmapRange = {},
+): Promise<HeatmapBucket[]> {
+  const qb = bountyRepo
+    .createQueryBuilder('bounty')
+    .select(PAYOUT_UTC_DATE_SQL, 'date')
+    .addSelect('COUNT(*)', 'count')
+    .where('bounty.claimedById = :userId', { userId })
+    .andWhere('bounty.status = :paid', { paid: BountyStatus.PAID })
+    .andWhere('bounty.paidAt IS NOT NULL');
+
+  if (range.from) {
+    qb.andWhere('bounty.paidAt >= :from', { from: range.from });
+  }
+  if (range.toExclusive) {
+    qb.andWhere('bounty.paidAt < :toExclusive', {
+      toExclusive: range.toExclusive,
+    });
+  }
+
+  const rows = await qb
+    .groupBy(PAYOUT_UTC_DATE_SQL)
+    .orderBy(PAYOUT_UTC_DATE_SQL, 'DESC')
+    .limit(HEATMAP_MAX_DAYS)
+    .getRawMany<{ date: string; count: string }>();
+
+  return heatmapFromRaw(rows);
+}
+
+export async function queryTopClients(
+  bountyRepo: Repository<Bounty>,
+  userId: string,
+): Promise<TopClientRow[]> {
+  const rows = await bountyRepo
+    .createQueryBuilder('bounty')
+    .select('bounty.sponsorId', 'sponsorId')
+    .addSelect('COALESCE(SUM(bounty.amount), 0)', 'totalPaid')
+    .where('bounty.claimedById = :userId', { userId })
+    .andWhere('bounty.status = :paid', { paid: BountyStatus.PAID })
+    .andWhere('bounty.sponsorId IS NOT NULL')
+    .groupBy('bounty.sponsorId')
+    .orderBy('totalPaid', 'DESC')
+    .limit(TOP_CLIENTS_LIMIT)
+    .getRawMany<{ sponsorId: string; totalPaid: string }>();
+
+  return rows.map((row) => ({
+    sponsorId: row.sponsorId,
+    totalPaid: Number(row.totalPaid),
+  }));
+}
+
+export async function queryContributorCoreStats(
+  bountyRepo: Repository<Bounty>,
+  userId: string,
+): Promise<ContributorCoreSqlStats> {
+  const [counts, languagesRows, orgsRows] = await Promise.all([
+    bountyRepo
+      .createQueryBuilder('bounty')
+      .leftJoin('bounty.issue', 'issue')
+      .leftJoin('issue.repository', 'repository')
+      .select('COUNT(*)', 'claimedCount')
+      .addSelect(
+        `COUNT(*) FILTER (WHERE bounty.status IN (${MERGED_SQL}))`,
+        'mergedCount',
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE bounty.status IN ('${BountyStatus.CLAIMED}', '${BountyStatus.IN_REVIEW}'))`,
+        'openBountiesClaimed',
+      )
+      .addSelect(
+        `COALESCE(SUM(bounty.amount) FILTER (WHERE bounty.status = '${BountyStatus.PAID}'), 0)`,
+        'lifetimeEarnings',
+      )
+      .addSelect(
+        `COALESCE(AVG(EXTRACT(EPOCH FROM (bounty.mergedAt - bounty.claimedAt)) / 3600) FILTER (WHERE bounty.status IN (${MERGED_SQL}) AND bounty.claimedAt IS NOT NULL AND bounty.mergedAt IS NOT NULL), 0)`,
+        'avgReviewTimeHours',
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE bounty.status IN (${MERGED_SQL}) AND (bounty.deadline IS NULL OR (bounty.mergedAt IS NOT NULL AND bounty.mergedAt <= bounty.deadline)))`,
+        'onTimeCount',
+      )
+      .addSelect('COUNT(DISTINCT issue.repositoryId)', 'repoCount')
+      .addSelect('COUNT(DISTINCT repository.owner)', 'orgCount')
+      .where('bounty.claimedById = :userId', { userId })
+      .getRawOne<{
+        claimedCount: string;
+        mergedCount: string;
+        openBountiesClaimed: string;
+        lifetimeEarnings: string;
+        avgReviewTimeHours: string;
+        onTimeCount: string;
+        repoCount: string;
+        orgCount: string;
+      }>(),
+    bountyRepo
+      .createQueryBuilder('bounty')
+      .innerJoin('bounty.issue', 'issue')
+      .innerJoin('issue.repository', 'repository')
+      .select('repository.primaryLanguage', 'lang')
+      .addSelect('COUNT(*)', 'count')
+      .where('bounty.claimedById = :userId', { userId })
+      .andWhere('repository.primaryLanguage IS NOT NULL')
+      .groupBy('repository.primaryLanguage')
+      .getRawMany<{ lang: string; count: string }>(),
+    bountyRepo
+      .createQueryBuilder('bounty')
+      .innerJoin('bounty.issue', 'issue')
+      .innerJoin('issue.repository', 'repository')
+      .select('DISTINCT repository.owner', 'owner')
+      .where('bounty.claimedById = :userId', { userId })
+      .andWhere('repository.owner IS NOT NULL')
+      .getRawMany<{ owner: string }>(),
+  ]);
+
+  const claimedCount = Number(counts?.claimedCount ?? 0);
+  const mergedCount = Number(counts?.mergedCount ?? 0);
+  const onTimeCount = Number(counts?.onTimeCount ?? 0);
+  const completionRate =
+    claimedCount > 0 ? (mergedCount / claimedCount) * 100 : 0;
+  const onTimeDeliveryPercentage =
+    mergedCount > 0 ? (onTimeCount / mergedCount) * 100 : 0;
+
+  const languages: Record<string, number> = {};
+  for (const row of languagesRows) {
+    languages[row.lang] = Number(row.count);
+  }
+
+  return {
+    claimedCount,
+    mergedCount,
+    completionRate,
+    avgReviewTimeHours: Number(counts?.avgReviewTimeHours ?? 0),
+    lifetimeEarnings: Number(counts?.lifetimeEarnings ?? 0),
+    openBountiesClaimed: Number(counts?.openBountiesClaimed ?? 0),
+    onTimeCount,
+    onTimeDeliveryPercentage,
+    repoCount: Number(counts?.repoCount ?? 0),
+    orgCount: Number(counts?.orgCount ?? 0),
+    languages,
+    orgs: orgsRows.map((row) => row.owner),
+  };
+}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -22,6 +22,13 @@ export interface AppConfig {
     apiToken: string;
     webhookSecret: string;
   };
+  analytics: {
+    /**
+     * In-process TTL for GET /analytics/platform. Also invalidated on
+     * bounty create/pay and first-time repository insert.
+     */
+    platformSummaryTtlMs: number;
+  };
   stellar: {
     network: string;
     sorobanRpcUrl: string;
@@ -79,6 +86,12 @@ export default (): AppConfig => ({
       'http://localhost:3000/api/auth/github/callback',
     apiToken: process.env.GITHUB_API_TOKEN ?? '',
     webhookSecret: process.env.GITHUB_WEBHOOK_SECRET ?? '',
+  },
+  analytics: {
+    platformSummaryTtlMs: parseInt(
+      process.env.ANALYTICS_PLATFORM_SUMMARY_TTL_MS ?? '60000',
+      10,
+    ),
   },
   stellar: {
     network: process.env.STELLAR_NETWORK ?? 'testnet',

--- a/src/database/migrations/1785100000000-AddAnalyticsBountyIndexes.ts
+++ b/src/database/migrations/1785100000000-AddAnalyticsBountyIndexes.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Composite + partial indexes for contributor analytics (heatmap / top
+ * clients / earnings filtered by claimedById+status) and the homepage
+ * SUM(amount) WHERE status = 'paid'.
+ */
+export class AddAnalyticsBountyIndexes1785100000000 implements MigrationInterface {
+  name = 'AddAnalyticsBountyIndexes1785100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_bounties_claimedById_status"
+      ON "bounties" ("claimedById", "status")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_bounties_status_paid"
+      ON "bounties" ("status")
+      WHERE "status" = 'paid'
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_bounties_paidAt_paid"
+      ON "bounties" ("paidAt")
+      WHERE "status" = 'paid' AND "paidAt" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_bounties_paidAt_paid"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_bounties_status_paid"`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_bounties_claimedById_status"`,
+    );
+  }
+}

--- a/src/github/github-sync.service.spec.ts
+++ b/src/github/github-sync.service.spec.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Issue, Repository } from '../common/entities';
 import {
   GithubSyncInterruptedError,
@@ -111,6 +112,7 @@ describe('GithubSyncService', () => {
         { provide: GITHUB_OCTOKIT, useValue: octokit },
         { provide: getRepositoryToken(Repository), useValue: repositoryRepo },
         { provide: getRepositoryToken(Issue), useValue: issueRepo },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/src/github/github-sync.service.ts
+++ b/src/github/github-sync.service.ts
@@ -1,7 +1,15 @@
-import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Octokit } from '@octokit/rest';
 import { Repository as TypeOrmRepository } from 'typeorm';
+import { ANALYTICS_PLATFORM_INVALIDATE_EVENT } from '../analytics/analytics.events';
 import { Issue, Repository } from '../common/entities';
 import { IssueState } from '../common/enums';
 import { GITHUB_OCTOKIT } from './octokit.provider';
@@ -77,9 +85,14 @@ export class GithubSyncService {
     private readonly repositoryRepo: TypeOrmRepository<Repository>,
     @InjectRepository(Issue)
     private readonly issueRepo: TypeOrmRepository<Issue>,
+    @Optional() private readonly eventEmitter?: EventEmitter2,
   ) {}
 
-  async syncRepository(owner: string, repo: string, page = 1): Promise<{ repository: Repository, synced: number, nextPage?: number }> {
+  async syncRepository(
+    owner: string,
+    repo: string,
+    page = 1,
+  ): Promise<{ repository: Repository; synced: number; nextPage?: number }> {
     const repoResponse = await this.octokit.repos.get({ owner, repo });
     this.logRateLimitFromHeaders(
       `before ${owner}/${repo}`,
@@ -91,6 +104,7 @@ export class GithubSyncService {
     let repository = await this.repositoryRepo.findOne({
       where: { githubRepoId: String(repoData.id) },
     });
+    const isNewRepository = !repository;
 
     const attrs = {
       githubRepoId: String(repoData.id),
@@ -109,9 +123,16 @@ export class GithubSyncService {
       ? this.repositoryRepo.merge(repository, attrs)
       : this.repositoryRepo.create(attrs);
     repository = await this.repositoryRepo.save(repository);
+    if (isNewRepository) {
+      this.eventEmitter?.emit(ANALYTICS_PLATFORM_INVALIDATE_EVENT);
+    }
 
     const result = await this.syncIssues(repository, owner, repo, page);
-    return { repository, synced: result.saved.length, nextPage: result.nextPage };
+    return {
+      repository,
+      synced: result.saved.length,
+      nextPage: result.nextPage,
+    };
   }
 
   /**
@@ -126,7 +147,7 @@ export class GithubSyncService {
     owner: string,
     repo: string,
     page = 1,
-  ): Promise<{ saved: Issue[], nextPage?: number }> {
+  ): Promise<{ saved: Issue[]; nextPage?: number }> {
     const saved: Issue[] = [];
 
     try {
@@ -155,7 +176,9 @@ export class GithubSyncService {
 
       const hasNextPage = response.headers.link?.includes('rel="next"');
 
-      this.logger.log(`Synced ${saved.length} issues for ${owner}/${repo} (page ${page})`);
+      this.logger.log(
+        `Synced ${saved.length} issues for ${owner}/${repo} (page ${page})`,
+      );
       return { saved, nextPage: hasNextPage ? page + 1 : undefined };
     } catch (err) {
       const cause = err as Error;
@@ -271,8 +294,16 @@ export class GithubSyncService {
     const limit = headers['x-ratelimit-limit'];
     const reset = headers['x-ratelimit-reset'];
     if (remaining != null && limit != null && reset != null) {
+      const remainingText =
+        typeof remaining === 'string' || typeof remaining === 'number'
+          ? String(remaining)
+          : 'unknown';
+      const limitText =
+        typeof limit === 'string' || typeof limit === 'number'
+          ? String(limit)
+          : 'unknown';
       this.logger.log(
-        `[rate-limit ${label}] core: ${remaining}/${limit} remaining, ` +
+        `[rate-limit ${label}] core: ${remainingText}/${limitText} remaining, ` +
           `resets at ${new Date(Number(reset) * 1000).toISOString()}`,
       );
     }

--- a/src/reputation/reputation.controller.ts
+++ b/src/reputation/reputation.controller.ts
@@ -5,13 +5,18 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ReputationService } from './reputation.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '../common/decorators/current-user.decorator';
+import {
+  REPUTATION_HISTORY_DEFAULT_LIMIT,
+  REPUTATION_HISTORY_MAX_LIMIT,
+} from './reputation.service';
 
 @ApiTags('reputation')
 @Controller('reputation')
@@ -51,11 +56,28 @@ export class ReputationController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Get(':userId/history')
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: `Default ${REPUTATION_HISTORY_DEFAULT_LIMIT}, max ${REPUTATION_HISTORY_MAX_LIMIT}`,
+  })
+  @ApiQuery({ name: 'offset', required: false })
   history(
     @Param('userId', new ParseUUIDPipe()) userId: string,
     @CurrentUser() user: AuthenticatedUser,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
   ) {
     this.assertOwner(user, userId);
-    return this.reputationService.history(userId);
+    return this.reputationService.history(userId, {
+      limit: parseOptionalInt(limit),
+      offset: parseOptionalInt(offset),
+    });
   }
+}
+
+function parseOptionalInt(value?: string): number | undefined {
+  if (value === undefined || value === '') return undefined;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) ? n : undefined;
 }

--- a/src/reputation/reputation.module.ts
+++ b/src/reputation/reputation.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Bounty, Issue, ReputationSnapshot } from '../common/entities';
+import { Bounty, ReputationSnapshot } from '../common/entities';
 import { ReputationService } from './reputation.service';
 import { ReputationController } from './reputation.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Bounty, Issue, ReputationSnapshot])],
+  imports: [TypeOrmModule.forFeature([Bounty, ReputationSnapshot])],
   controllers: [ReputationController],
   providers: [ReputationService],
   exports: [ReputationService],

--- a/src/reputation/reputation.service.spec.ts
+++ b/src/reputation/reputation.service.spec.ts
@@ -1,23 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ReputationService } from './reputation.service';
-import { Bounty, Issue, ReputationSnapshot } from '../common/entities';
-import { BountyStatus } from '../common/enums';
-import * as statsUtil from '../common/stats/contributor-stats.util';
+import { Bounty, ReputationSnapshot } from '../common/entities';
+import * as sql from '../common/stats/contributor-stats.sql';
+
+jest.mock('../common/stats/contributor-stats.sql', () => ({
+  queryContributorCoreStats: jest.fn(),
+}));
+
+const mockedSql = sql as jest.Mocked<typeof sql>;
 
 describe('ReputationService', () => {
   let service: ReputationService;
 
   const mockBountyRepo = {
     find: jest.fn(),
-  };
-
-  const mockIssueRepo = {
-    find: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockSnapshotRepo = {
-    create: jest.fn((dto) => dto),
+    create: jest.fn((dto: Record<string, unknown>) => dto),
     save: jest.fn((entity) => Promise.resolve({ id: 'snap-1', ...entity })),
     findOne: jest.fn(),
     find: jest.fn(),
@@ -28,8 +30,10 @@ describe('ReputationService', () => {
       providers: [
         ReputationService,
         { provide: getRepositoryToken(Bounty), useValue: mockBountyRepo },
-        { provide: getRepositoryToken(Issue), useValue: mockIssueRepo },
-        { provide: getRepositoryToken(ReputationSnapshot), useValue: mockSnapshotRepo },
+        {
+          provide: getRepositoryToken(ReputationSnapshot),
+          useValue: mockSnapshotRepo,
+        },
       ],
     }).compile();
 
@@ -41,11 +45,17 @@ describe('ReputationService', () => {
   });
 
   it('should handle empty input correctly (zero bounties)', async () => {
-    mockBountyRepo.find.mockResolvedValue([]);
-    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+    mockedSql.queryContributorCoreStats.mockResolvedValue({
+      claimedCount: 0,
       mergedCount: 0,
       completionRate: 0,
       avgReviewTimeHours: 0,
+      lifetimeEarnings: 0,
+      openBountiesClaimed: 0,
+      onTimeCount: 0,
+      onTimeDeliveryPercentage: 0,
+      repoCount: 0,
+      orgCount: 0,
       languages: {},
       orgs: [],
     });
@@ -56,27 +66,42 @@ describe('ReputationService', () => {
     expect(result.openBountiesClaimed).toBe(0);
     expect(result.completionRate).toBe('0.00');
     expect(result.onTimeDeliveryPercentage).toBe('0.00');
+    expect(mockBountyRepo.find).not.toHaveBeenCalled();
   });
 
   it('should compute completion-rate and on-time-delivery math correctly', async () => {
-    mockBountyRepo.find.mockResolvedValue([
-      { status: BountyStatus.PAID, amount: '100', deadline: new Date('2023-01-02'), mergedAt: new Date('2023-01-01') },
-      { status: BountyStatus.MERGED, amount: '0', deadline: new Date('2023-01-01'), mergedAt: new Date('2023-01-02') }, // Late
-      { status: BountyStatus.CLAIMED, amount: '50' },
-    ]);
-    mockIssueRepo.find.mockResolvedValue([]);
-    jest.spyOn(statsUtil, 'computeContributorStats').mockReturnValue({
+    mockedSql.queryContributorCoreStats.mockResolvedValue({
+      claimedCount: 3,
       mergedCount: 2,
-      completionRate: 66.67,
+      completionRate: (2 / 3) * 100,
       avgReviewTimeHours: 2.5,
+      lifetimeEarnings: 100,
+      openBountiesClaimed: 1,
+      onTimeCount: 1,
+      onTimeDeliveryPercentage: 50,
+      repoCount: 0,
+      orgCount: 0,
       languages: {},
       orgs: [],
     });
 
     const result = await service.computeAndSave('user-1');
-    expect(result.totalEarnings).toBe('100.0000000'); // only PAID
-    expect(result.openBountiesClaimed).toBe(1); // CLAIMED
+    expect(result.totalEarnings).toBe('100.0000000');
+    expect(result.openBountiesClaimed).toBe(1);
     expect(result.completionRate).toBe('66.67');
-    expect(result.onTimeDeliveryPercentage).toBe('50.00'); // 1 on-time out of 2 merged
+    expect(result.onTimeDeliveryPercentage).toBe('50.00');
+  });
+
+  it('paginates history with a default/max limit', async () => {
+    mockSnapshotRepo.find.mockResolvedValue([]);
+    await service.history('user-1');
+    expect(mockSnapshotRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 50, skip: 0 }),
+    );
+
+    await service.history('user-1', { limit: 1000, offset: 10 });
+    expect(mockSnapshotRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 100, skip: 10 }),
+    );
   });
 });

--- a/src/reputation/reputation.service.ts
+++ b/src/reputation/reputation.service.ts
@@ -1,58 +1,40 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Bounty, Issue, ReputationSnapshot } from '../common/entities';
-import { BountyStatus } from '../common/enums';
-import { computeContributorStats } from '../common/stats/contributor-stats.util';
+import { Bounty, ReputationSnapshot } from '../common/entities';
+import { queryContributorCoreStats } from '../common/stats/contributor-stats.sql';
+
+export const REPUTATION_HISTORY_DEFAULT_LIMIT = 50;
+export const REPUTATION_HISTORY_MAX_LIMIT = 100;
+
+export interface ReputationHistoryOptions {
+  limit?: number;
+  offset?: number;
+}
 
 @Injectable()
 export class ReputationService {
   constructor(
     @InjectRepository(Bounty) private readonly bountyRepo: Repository<Bounty>,
-    @InjectRepository(Issue) private readonly issueRepo: Repository<Issue>,
     @InjectRepository(ReputationSnapshot)
     private readonly snapshotRepo: Repository<ReputationSnapshot>,
   ) {}
 
   /**
-   * Recomputes a contributor's reputation stats from their historical bounty
-   * activity and appends a new snapshot row.
+   * Recomputes a contributor's reputation stats from SQL aggregates of their
+   * bounty activity and appends a new snapshot row.
    */
   async computeAndSave(userId: string): Promise<ReputationSnapshot> {
-    const claimedBounties = await this.bountyRepo.find({
-      where: { claimedById: userId },
-    });
-    const issues = claimedBounties.length
-      ? await this.issueRepo.find({
-          where: claimedBounties.map((b) => ({ id: b.issueId })),
-          relations: { repository: true },
-        })
-      : [];
-
-    const stats = computeContributorStats(claimedBounties, issues);
-
-    const merged = claimedBounties.filter((b) =>
-      [BountyStatus.MERGED, BountyStatus.PAID].includes(b.status),
-    );
-    const paid = claimedBounties.filter((b) => b.status === BountyStatus.PAID);
-    const totalEarnings = paid.reduce((sum, b) => sum + Number(b.amount), 0);
-
-    const onTime = merged.filter(
-      (b) => !b.deadline || (b.mergedAt && b.mergedAt <= b.deadline),
-    );
-    const onTimeDeliveryPercentage =
-      merged.length > 0 ? (onTime.length / merged.length) * 100 : 0;
+    const stats = await queryContributorCoreStats(this.bountyRepo, userId);
 
     const snapshot = this.snapshotRepo.create({
       userId,
-      totalEarnings: totalEarnings.toFixed(7),
+      totalEarnings: stats.lifetimeEarnings.toFixed(7),
       mergedPrCount: stats.mergedCount,
-      openBountiesClaimed: claimedBounties.filter((b) =>
-        [BountyStatus.CLAIMED, BountyStatus.IN_REVIEW].includes(b.status),
-      ).length,
+      openBountiesClaimed: stats.openBountiesClaimed,
       completionRate: stats.completionRate.toFixed(2),
       avgReviewTimeHours: stats.avgReviewTimeHours.toFixed(2),
-      onTimeDeliveryPercentage: onTimeDeliveryPercentage.toFixed(2),
+      onTimeDeliveryPercentage: stats.onTimeDeliveryPercentage.toFixed(2),
       languages: stats.languages,
       orgsContributedTo: stats.orgs,
     });
@@ -66,10 +48,20 @@ export class ReputationService {
     });
   }
 
-  async history(userId: string): Promise<ReputationSnapshot[]> {
+  async history(
+    userId: string,
+    options: ReputationHistoryOptions = {},
+  ): Promise<ReputationSnapshot[]> {
+    const limit = Math.min(
+      Math.max(options.limit ?? REPUTATION_HISTORY_DEFAULT_LIMIT, 1),
+      REPUTATION_HISTORY_MAX_LIMIT,
+    );
+    const offset = Math.max(options.offset ?? 0, 0);
     return this.snapshotRepo.find({
       where: { userId },
       order: { computedAt: 'ASC' },
+      take: limit,
+      skip: offset,
     });
   }
 }


### PR DESCRIPTION
## Summary

- Introduced in-process caching for the platform summary endpoint, with a default TTL of 60 seconds, which is invalidated on bounty creation, payment, or repository sync.
- Updated the analytics service to utilize SQL queries for contributor stats and heatmap data.
- Added a new environment variable `ANALYTICS_PLATFORM_SUMMARY_TTL_MS` to configure the caching duration.
- Enhanced the analytics controller to support query parameters for contributor analytics.
- Updated README and .env.example to reflect new analytics configurations and usage.

Closes: #22 